### PR TITLE
feat(auth): add supabase register/login/refresh/logout baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/funeralface
 
 # Supabase (server-side invite; service role must never ship to mobile)
 SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=replace-with-anon-key
 SUPABASE_SERVICE_ROLE_KEY=replace-with-service-role-key
 
 # CORS

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,6 +54,92 @@ paths:
                 $ref: '#/components/schemas/AuthMeResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+  /v1/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register new user account
+      operationId: postAuthRegister
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthCredentialsRequest'
+      responses:
+        '201':
+          description: Account created (session may be null if email confirmation is required)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '503':
+          description: Auth service not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/auth/login:
+    post:
+      tags: [Auth]
+      summary: Login with email and password
+      operationId: postAuthLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthCredentialsRequest'
+      responses:
+        '200':
+          description: Authenticated session payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /v1/auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Refresh access token
+      operationId: postAuthRefresh
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthRefreshRequest'
+      responses:
+        '200':
+          description: Refreshed session payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /v1/auth/logout:
+    post:
+      tags: [Auth]
+      summary: Logout current access token session
+      operationId: postAuthLogout
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthLogoutRequest'
+      responses:
+        '204':
+          description: Logout accepted
+        '400':
+          $ref: '#/components/responses/BadRequestError'
   /v1/staff/invite:
     post:
       tags: [Staff]
@@ -386,6 +472,41 @@ components:
         role:
           type: string
         org_id:
+          type: string
+    AuthCredentialsRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+    AuthSessionResponse:
+      type: object
+      required: [user_id, access_token, refresh_token]
+      properties:
+        user_id:
+          type: string
+          nullable: true
+        access_token:
+          type: string
+          nullable: true
+        refresh_token:
+          type: string
+          nullable: true
+    AuthRefreshRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
+    AuthLogoutRequest:
+      type: object
+      required: [access_token]
+      properties:
+        access_token:
           type: string
     StaffInviteRequest:
       type: object

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,8 +28,14 @@ import {
 } from "./services/assignmentService";
 import { createPublicTokenRateLimit } from "./middleware/publicTokenRateLimit";
 import { defaultFamilyTokenService, type FamilyTokenService } from "./services/familyTokenService";
+import {
+  AuthNotConfiguredError,
+  defaultAuthService,
+  type AuthService,
+} from "./services/authService";
 
 export type AppDependencies = {
+  authService?: AuthService;
   inviteUserByEmail?: (email: string) => Promise<void>;
   settingsService?: SettingsService;
   staffService?: StaffService;
@@ -44,6 +50,7 @@ export function createApp(deps: AppDependencies = {}): Express {
   app.use(express.json());
 
   const inviteUserByEmail = deps.inviteUserByEmail ?? defaultInviteUserByEmail;
+  const authService = deps.authService ?? defaultAuthService;
   const settingsService = deps.settingsService ?? defaultSettingsService;
   const staffService = deps.staffService ?? defaultStaffService;
   const assignmentService = deps.assignmentService ?? defaultAssignmentService;
@@ -65,6 +72,104 @@ export function createApp(deps: AppDependencies = {}): Express {
       role: req.auth?.role,
       org_id: req.auth?.orgId,
     });
+  });
+
+  app.post("/v1/auth/register", async (req: Request, res: Response) => {
+    const email = typeof req.body?.email === "string" ? req.body.email.trim() : "";
+    const password = typeof req.body?.password === "string" ? req.body.password : "";
+    if (!email || !isValidEmail(email) || password.length < 8) {
+      res.status(400).json({
+        code: "bad_request",
+        message: "Valid email and password (min 8 chars) are required.",
+      });
+      return;
+    }
+    try {
+      const data = await authService.register(email, password);
+      res.status(201).json(data);
+    } catch (error) {
+      if (error instanceof AuthNotConfiguredError) {
+        res.status(503).json({ code: "service_unavailable", message: error.message });
+        return;
+      }
+      res.status(400).json({
+        code: "auth_failed",
+        message: error instanceof Error ? error.message : "Register failed.",
+      });
+    }
+  });
+
+  app.post("/v1/auth/login", async (req: Request, res: Response) => {
+    const email = typeof req.body?.email === "string" ? req.body.email.trim() : "";
+    const password = typeof req.body?.password === "string" ? req.body.password : "";
+    if (!email || !isValidEmail(email) || !password) {
+      res.status(400).json({
+        code: "bad_request",
+        message: "Valid email and password are required.",
+      });
+      return;
+    }
+    try {
+      const data = await authService.login(email, password);
+      res.status(200).json(data);
+    } catch (error) {
+      if (error instanceof AuthNotConfiguredError) {
+        res.status(503).json({ code: "service_unavailable", message: error.message });
+        return;
+      }
+      res.status(401).json({
+        code: "unauthorized",
+        message: error instanceof Error ? error.message : "Login failed.",
+      });
+    }
+  });
+
+  app.post("/v1/auth/refresh", async (req: Request, res: Response) => {
+    const refreshToken = typeof req.body?.refresh_token === "string" ? req.body.refresh_token.trim() : "";
+    if (!refreshToken) {
+      res.status(400).json({
+        code: "bad_request",
+        message: "refresh_token is required.",
+      });
+      return;
+    }
+    try {
+      const data = await authService.refresh(refreshToken);
+      res.status(200).json(data);
+    } catch (error) {
+      if (error instanceof AuthNotConfiguredError) {
+        res.status(503).json({ code: "service_unavailable", message: error.message });
+        return;
+      }
+      res.status(401).json({
+        code: "unauthorized",
+        message: error instanceof Error ? error.message : "Refresh failed.",
+      });
+    }
+  });
+
+  app.post("/v1/auth/logout", async (req: Request, res: Response) => {
+    const accessToken = typeof req.body?.access_token === "string" ? req.body.access_token.trim() : "";
+    if (!accessToken) {
+      res.status(400).json({
+        code: "bad_request",
+        message: "access_token is required.",
+      });
+      return;
+    }
+    try {
+      await authService.logout(accessToken);
+      res.status(204).send();
+    } catch (error) {
+      if (error instanceof AuthNotConfiguredError) {
+        res.status(503).json({ code: "service_unavailable", message: error.message });
+        return;
+      }
+      res.status(400).json({
+        code: "auth_failed",
+        message: error instanceof Error ? error.message : "Logout failed.",
+      });
+    }
   });
 
   app.post(

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,95 @@
+import { createClient } from "@supabase/supabase-js";
+
+export class AuthNotConfiguredError extends Error {
+  constructor(message = "Supabase auth service is not configured.") {
+    super(message);
+    this.name = "AuthNotConfiguredError";
+  }
+}
+
+export type RegisterResult = {
+  user_id: string | null;
+  access_token: string | null;
+  refresh_token: string | null;
+};
+
+export type LoginResult = {
+  user_id: string;
+  access_token: string;
+  refresh_token: string;
+};
+
+export type RefreshResult = {
+  user_id: string;
+  access_token: string;
+  refresh_token: string;
+};
+
+export type AuthService = {
+  register(email: string, password: string): Promise<RegisterResult>;
+  login(email: string, password: string): Promise<LoginResult>;
+  refresh(refreshToken: string): Promise<RefreshResult>;
+  logout(accessToken: string): Promise<void>;
+};
+
+function getAuthClient() {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new AuthNotConfiguredError();
+  }
+  return createClient(url, anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+export const defaultAuthService: AuthService = {
+  async register(email: string, password: string): Promise<RegisterResult> {
+    const client = getAuthClient();
+    const { data, error } = await client.auth.signUp({ email, password });
+    if (error) throw error;
+    return {
+      user_id: data.user?.id ?? null,
+      access_token: data.session?.access_token ?? null,
+      refresh_token: data.session?.refresh_token ?? null,
+    };
+  },
+
+  async login(email: string, password: string): Promise<LoginResult> {
+    const client = getAuthClient();
+    const { data, error } = await client.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+    if (!data.user?.id || !data.session?.access_token || !data.session?.refresh_token) {
+      throw new Error("Login did not return a complete auth session.");
+    }
+    return {
+      user_id: data.user.id,
+      access_token: data.session.access_token,
+      refresh_token: data.session.refresh_token,
+    };
+  },
+
+  async refresh(refreshToken: string): Promise<RefreshResult> {
+    const client = getAuthClient();
+    const { data, error } = await client.auth.refreshSession({ refresh_token: refreshToken });
+    if (error) throw error;
+    if (!data.user?.id || !data.session?.access_token || !data.session?.refresh_token) {
+      throw new Error("Refresh did not return a complete auth session.");
+    }
+    return {
+      user_id: data.user.id,
+      access_token: data.session.access_token,
+      refresh_token: data.session.refresh_token,
+    };
+  },
+
+  async logout(accessToken: string): Promise<void> {
+    const client = getAuthClient();
+    void accessToken;
+    const { error } = await client.auth.signOut();
+    if (error) throw error;
+  },
+};

--- a/test/auth/authEndpoints.test.ts
+++ b/test/auth/authEndpoints.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import request from "supertest";
+import { createApp } from "../../src/app";
+import type { AuthService } from "../../src/services/authService";
+
+const fakeAuthService: AuthService = {
+  async register(email, _password) {
+    return {
+      user_id: `u-${email}`,
+      access_token: "at-register",
+      refresh_token: "rt-register",
+    };
+  },
+  async login(email, _password) {
+    return {
+      user_id: `u-${email}`,
+      access_token: "at-login",
+      refresh_token: "rt-login",
+    };
+  },
+  async refresh(_refreshToken) {
+    return {
+      user_id: "u-refresh",
+      access_token: "at-refresh",
+      refresh_token: "rt-refresh",
+    };
+  },
+  async logout(_accessToken) {},
+};
+
+test("POST /v1/auth/register validates body", async () => {
+  const app = createApp({ authService: fakeAuthService });
+  const res = await request(app).post("/v1/auth/register").send({ email: "x", password: "123" });
+  assert.equal(res.status, 400);
+});
+
+test("POST /v1/auth/register returns session payload", async () => {
+  const app = createApp({ authService: fakeAuthService });
+  const res = await request(app)
+    .post("/v1/auth/register")
+    .send({ email: "user@example.com", password: "password123" });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.access_token, "at-register");
+});
+
+test("POST /v1/auth/login returns session payload", async () => {
+  const app = createApp({ authService: fakeAuthService });
+  const res = await request(app)
+    .post("/v1/auth/login")
+    .send({ email: "user@example.com", password: "password123" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.access_token, "at-login");
+});
+
+test("POST /v1/auth/refresh returns new tokens", async () => {
+  const app = createApp({ authService: fakeAuthService });
+  const res = await request(app).post("/v1/auth/refresh").send({ refresh_token: "rt-login" });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.access_token, "at-refresh");
+});
+
+test("POST /v1/auth/logout returns 204", async () => {
+  const app = createApp({ authService: fakeAuthService });
+  const res = await request(app).post("/v1/auth/logout").send({ access_token: "at-login" });
+  assert.equal(res.status, 204);
+});


### PR DESCRIPTION
Implement Ticket 1-3 backend auth baseline with Supabase-backed auth service, new /v1/auth/register|login|refresh|logout endpoints, OpenAPI contract updates, and API tests using injected auth service doubles.
