### PR TITLE
feat(auth): Supabase access token verification and org bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,10 @@
 NODE_ENV=development
 PORT=8010
 
-# Security
-JWT_SECRET=replace-with-strong-secret
+# Security — HS256 test/dev tokens only (e.g. API tests). Sign with jsonwebtoken using claims sub, org_id, role.
+# Production/mobile: Supabase access tokens are ES256; requireAuth validates them via Supabase getUser + staff_members lookup.
+# JWT_SECRET is not used to verify Supabase user JWTs. Keep set for local tests that mock HS256 Bearer tokens.
+JWT_SECRET=local-test-secret-only
 
 # Database
 # Local default for development only. Use your Supabase Postgres URL in staging/production.

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import type { Express, Request, RequestHandler, Response } from "express";
 import { requireAuth, type AuthenticatedRequest } from "./auth/authMiddleware";
+import { getUserFromSupabaseAccessToken } from "./auth/supabaseAccessTokenUser";
 import { requireRole } from "./auth/requireRole";
 import {
   defaultInviteUserByEmail,
@@ -74,6 +75,37 @@ export function createApp(deps: AppDependencies = {}): Express {
     });
   });
 
+  app.post("/v1/auth/ensure-provisioned", async (req: Request, res: Response) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith("Bearer ")) {
+      res.status(401).json({ code: "unauthorized", message: "Bearer token is required." });
+      return;
+    }
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) {
+      res.status(401).json({ code: "unauthorized", message: "Bearer token is required." });
+      return;
+    }
+    const user = await getUserFromSupabaseAccessToken(token);
+    if (!user) {
+      res.status(401).json({ code: "unauthorized", message: "Invalid authentication token." });
+      return;
+    }
+    if (!process.env.DATABASE_URL?.trim()) {
+      res.status(503).json({ code: "service_unavailable", message: "Database is not configured." });
+      return;
+    }
+    try {
+      const row = await staffService.bootstrapOrgAndAdminForUser(user.id, user.email ?? "");
+      res.status(200).json({ org_id: row.org_id, role: row.role });
+    } catch (error) {
+      res.status(500).json({
+        code: "provision_failed",
+        message: error instanceof Error ? error.message : "Provisioning failed.",
+      });
+    }
+  });
+
   app.post("/v1/auth/register", async (req: Request, res: Response) => {
     const email = typeof req.body?.email === "string" ? req.body.email.trim() : "";
     const password = typeof req.body?.password === "string" ? req.body.password : "";
@@ -86,6 +118,13 @@ export function createApp(deps: AppDependencies = {}): Express {
     }
     try {
       const data = await authService.register(email, password);
+      if (
+        data.user_id &&
+        data.access_token &&
+        process.env.DATABASE_URL?.trim()
+      ) {
+        await staffService.bootstrapOrgAndAdminForUser(data.user_id, email);
+      }
       res.status(201).json(data);
     } catch (error) {
       if (error instanceof AuthNotConfiguredError) {
@@ -111,6 +150,9 @@ export function createApp(deps: AppDependencies = {}): Express {
     }
     try {
       const data = await authService.login(email, password);
+      if (process.env.DATABASE_URL?.trim()) {
+        await staffService.bootstrapOrgAndAdminForUser(data.user_id, email);
+      }
       res.status(200).json(data);
     } catch (error) {
       if (error instanceof AuthNotConfiguredError) {

--- a/src/auth/authMiddleware.ts
+++ b/src/auth/authMiddleware.ts
@@ -1,5 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
+import { defaultStaffService } from "../services/staffService";
+import { getUserFromSupabaseAccessToken } from "./supabaseAccessTokenUser";
 
 export type AuthenticatedRequest = Request & {
   auth?: {
@@ -15,7 +17,11 @@ type JwtPayload = {
   org_id?: string;
 };
 
-export function requireAuth(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+export async function requireAuth(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
@@ -26,23 +32,65 @@ export function requireAuth(req: AuthenticatedRequest, res: Response, next: Next
     return;
   }
 
-  const token = authHeader.slice("Bearer ".length);
-  const secret = process.env.JWT_SECRET;
-  if (!secret || !secret.trim()) {
-    res.status(503).json({
-      code: "auth_not_configured",
-      message: "Authentication is not configured (JWT_SECRET missing).",
+  const token = authHeader.slice("Bearer ".length).trim();
+  if (!token) {
+    res.status(401).json({
+      code: "unauthorized",
+      message: "Authentication is required.",
     });
     return;
   }
 
   try {
-    const decoded = jwt.verify(token, secret) as JwtPayload;
-    const userId = decoded.sub;
-    const role = decoded.role ?? "user";
-    const orgId = decoded.org_id;
+    const header = jwt.decode(token, { complete: true })?.header;
+    const alg = header?.alg;
 
-    if (!userId || !orgId) {
+    const secret = process.env.JWT_SECRET?.trim();
+    if (alg === "HS256" && secret) {
+      const decoded = jwt.verify(token, secret) as JwtPayload;
+      const userId = decoded.sub;
+      const role = decoded.role ?? "user";
+      const orgId = decoded.org_id;
+
+      if (!userId || !orgId) {
+        res.status(401).json({
+          code: "unauthorized",
+          message: "Invalid authentication token.",
+        });
+        return;
+      }
+
+      req.auth = {
+        userId,
+        role,
+        orgId,
+      };
+      next();
+      return;
+    }
+
+    const user = await getUserFromSupabaseAccessToken(token);
+    if (user) {
+      const row = await defaultStaffService.findOrgRoleByUserId(user.id);
+      if (!row) {
+        res.status(401).json({
+          code: "unauthorized",
+          message:
+            "Account is not provisioned for this app. Sign out, sign in again, or register to create your organization.",
+        });
+        return;
+      }
+
+      req.auth = {
+        userId: user.id,
+        role: row.role,
+        orgId: row.org_id,
+      };
+      next();
+      return;
+    }
+
+    if (process.env.SUPABASE_URL?.trim() && process.env.SUPABASE_ANON_KEY?.trim()) {
       res.status(401).json({
         code: "unauthorized",
         message: "Invalid authentication token.",
@@ -50,13 +98,18 @@ export function requireAuth(req: AuthenticatedRequest, res: Response, next: Next
       return;
     }
 
-    req.auth = {
-      userId,
-      role,
-      orgId,
-    };
+    if (!secret) {
+      res.status(503).json({
+        code: "auth_not_configured",
+        message: "Authentication is not configured (JWT_SECRET missing).",
+      });
+      return;
+    }
 
-    next();
+    res.status(401).json({
+      code: "unauthorized",
+      message: "Invalid authentication token.",
+    });
   } catch {
     res.status(401).json({
       code: "unauthorized",

--- a/src/auth/supabaseAccessTokenUser.ts
+++ b/src/auth/supabaseAccessTokenUser.ts
@@ -1,0 +1,18 @@
+import { createClient, type User } from "@supabase/supabase-js";
+
+/** Validates a Supabase access token (ES256) and returns the user, or null. */
+export async function getUserFromSupabaseAccessToken(accessToken: string): Promise<User | null> {
+  const url = process.env.SUPABASE_URL?.trim();
+  const anon = process.env.SUPABASE_ANON_KEY?.trim();
+  if (!url || !anon) return null;
+
+  const supabase = createClient(url, anon, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  if (error || !data.user) return null;
+  return data.user;
+}

--- a/src/services/staffService.ts
+++ b/src/services/staffService.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
+import { defaultSettingsService } from "./settingsService";
 
 export type StaffMemberRecord = {
   id: string;
@@ -28,8 +29,12 @@ export type ListStaffInput = {
   pageSize?: number;
 };
 
+export type OrgRoleForUser = { org_id: string; role: string };
+
 export type StaffService = {
   listByOrgId: (orgId: string, input: ListStaffInput) => Promise<StaffMemberRecord[]>;
+  findOrgRoleByUserId: (userId: string) => Promise<OrgRoleForUser | null>;
+  bootstrapOrgAndAdminForUser: (userId: string, email: string) => Promise<OrgRoleForUser>;
   createByOrgId: (
     orgId: string,
     input: StaffCreateInput,
@@ -63,6 +68,66 @@ function normalizeRole(role?: string): string {
 }
 
 export const defaultStaffService: StaffService = {
+  async findOrgRoleByUserId(userId) {
+    const pool = getPgPool();
+    const result = await pool.query<OrgRoleForUser>(
+      `
+      SELECT org_id, role
+      FROM staff_members
+      WHERE id = $1 AND active = true
+      LIMIT 1
+      `,
+      [userId],
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async bootstrapOrgAndAdminForUser(userId, email) {
+    const existing = await this.findOrgRoleByUserId(userId);
+    if (existing) return existing;
+
+    const pool = getPgPool();
+    const orgId = randomUUID();
+    const safeEmail = email.trim();
+    const displayName =
+      safeEmail.includes("@") ? safeEmail.split("@")[0]!.trim() || "Admin" : safeEmail || "Admin";
+
+    await defaultSettingsService.upsertByOrgId(orgId, {
+      funeral_home_name: displayName,
+      funeral_home_phone: "—",
+      funeral_home_address: "—",
+    });
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        `
+        INSERT INTO staff_members (id, org_id, name, phone, email, role, active)
+        VALUES ($1, $2, $3, $4, $5, 'admin', true)
+        `,
+        [userId, orgId, displayName, "0000000000", safeEmail || null],
+      );
+      await client.query(
+        `
+        INSERT INTO staff_audit_logs (
+          id, staff_member_id, org_id, action, to_role, to_active, changed_by_user_id
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `,
+        [randomUUID(), userId, orgId, "created", "admin", true, userId],
+      );
+      await client.query("COMMIT");
+    } catch (e) {
+      await client.query("ROLLBACK");
+      throw e;
+    } finally {
+      client.release();
+    }
+
+    return { org_id: orgId, role: "admin" };
+  },
+
   async listByOrgId(orgId, input) {
     const pool = getPgPool();
     const sort = input.sort === "-created_at" ? "DESC" : "ASC";
@@ -88,7 +153,7 @@ export const defaultStaffService: StaffService = {
     const pool = getPgPool();
     const result = await pool.query<StaffMemberRecord>(
       `
-      INSERT INTO staff_members (id, org_id, name, phone, email, role)
+      INSERT INTO staff_members (id, org_id, name, phone, email, role, active)
       VALUES ($1, $2, $3, $4, $5, $6, $7)
       RETURNING id, org_id, name, phone, email, role, active, created_at
       `,


### PR DESCRIPTION
- Resolve staff context via Supabase getUser + staff_members lookup (ES256)

- Keep HS256 JWT path for tests; bootstrap org/admin on register/login

- POST /v1/auth/ensure-provisioned for clients that only use Supabase sign-in
