### PR TITLE
fix(deploy): Railway build and correct dist entry for npm start

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+# Railway: compile TypeScript before `npm start`.
+# `NODE_ENV=production` installs omit devDependencies by default; TypeScript is required to build.
+[build]
+buildCommand = "npm ci --include=dev && npm run build"
+
+[deploy]
+startCommand = "npm start"
+healthcheckPath = "/v1/health"
+healthcheckTimeout = 300

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "rootDir": ".",
+    "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
- Add railway.toml: npm ci --include=dev && npm run build before start (TypeScript is a devDependency)

- Set tsconfig rootDir to src so tsc emits dist/server.js matching package.json start script
