### PR TITLE
fix(deploy): use Dockerfile on Railway so dist is always in the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.env
+.env.*
+!.env.example
+coverage
+*.log
+test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Production image: install (with devDeps for tsc), compile, prune, run.
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+# Install all deps so `typescript` is available for `npm run build`
+RUN npm ci --include=dev
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build && npm prune --omit=dev
+
+ENV NODE_ENV=production
+# Railway sets PORT at runtime; default matches local dev
+ENV PORT=8010
+
+EXPOSE 8010
+CMD ["node", "dist/server.js"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,10 @@
-# Railway: compile TypeScript before `npm start`.
-# `NODE_ENV=production` installs omit devDependencies by default; TypeScript is required to build.
+# Use Docker so `dist/` is always produced in the same image that runs `node`.
+# (Railpack/Nixpacks may skip or not persist custom buildCommand in some setups.)
 [build]
-buildCommand = "npm ci --include=dev && npm run build"
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "npm start"
+startCommand = "node dist/server.js"
 healthcheckPath = "/v1/health"
 healthcheckTimeout = 300


### PR DESCRIPTION
Railpack/Nixpacks was only running npm start without a reliable compile step. Docker build runs tsc then prunes devDependencies; start runs node dist/server.js directly.
