### PR TITLE
docs: SendGrid SMTP for Supabase staff invite emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,21 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=replace-with-anon-key
 SUPABASE_SERVICE_ROLE_KEY=replace-with-service-role-key
 
+# Staff invitation emails (SendGrid + Supabase — no extra vars here)
+# ------------------------------------------------------------------
+# POST /v1/staff/invite calls supabase.auth.admin.inviteUserByEmail().
+# Supabase sends that email. To use SendGrid:
+#   1) SendGrid: create an API key; verify Sender Identity (single sender or domain auth).
+#   2) Supabase Dashboard → Project Settings → Authentication → SMTP Settings
+#      Enable custom SMTP, for example:
+#        Host: smtp.sendgrid.net
+#        Port: 587
+#        Username: apikey
+#        Password: <your SendGrid API key>
+#        Sender email: your verified from-address in SendGrid
+#        Sender name: Funeralface (or your org)
+#   3) Save. Invites from the app still only need SUPABASE_* on this API; mail goes via SendGrid.
+# See README.md → “Staff invites (SendGrid)”.
+
 # CORS
 ALLOWED_ORIGINS=http://localhost:8010,http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Funeralface Backend
+
+TypeScript Express API for Funeralface. Contract: `openapi.yaml`.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill values.
+2. Install: `npm ci`
+3. Build: `npm run build`
+4. Run migrations: `npm run db:migrate` (requires `DATABASE_URL`)
+5. Dev server: `npm run dev` (default port **8010**)
+
+## Tests
+
+```bash
+npm test
+```
+
+## Staff invites (SendGrid)
+
+Invites from `POST /v1/staff/invite` use **Supabase Auth** `inviteUserByEmail`. Supabase sends the message, so **outbound mail is configured in the Supabase project**, not via new variables in this repo.
+
+### SendGrid
+
+1. In [SendGrid](https://sendgrid.com/), create an **API key** with Mail Send permission.
+2. Complete **Sender Authentication** (recommended: **domain**; minimum: **Single Sender Verification**) so your “from” address is allowed.
+3. In [Supabase Dashboard](https://supabase.com/dashboard) → your project → **Project Settings** → **Authentication** → **SMTP Settings**:
+   - Enable **custom SMTP**
+   - **Host:** `smtp.sendgrid.net`
+   - **Port:** `587`
+   - **Username:** `apikey` (literal string)
+   - **Password:** your SendGrid API key
+   - **Sender email / name:** must match a verified sender in SendGrid
+
+4. Save. Optional: under **Authentication** → **Email Templates**, customize the **Invite user** template.
+
+### This API (Railway, etc.)
+
+Keep **`SUPABASE_URL`** and **`SUPABASE_SERVICE_ROLE_KEY`** set. No SendGrid secrets are required in this service unless you later add direct SendGrid API calls.
+
+Official references: [Supabase custom SMTP](https://supabase.com/docs/guides/auth/auth-smtp), [SendGrid SMTP](https://docs.sendgrid.com/for-developers/sending-email/getting-started-smtp).
+
+## Deploy (Railway)
+
+Uses `Dockerfile` and `railway.toml`. Set the same env vars as production (especially `DATABASE_URL`, `JWT_SECRET`, Supabase keys). Run `npm run db:migrate` against the production database before or after first deploy.

--- a/src/services/inviteStaff.ts
+++ b/src/services/inviteStaff.ts
@@ -1,5 +1,11 @@
 import { createClient } from "@supabase/supabase-js";
 
+/**
+ * Sends staff invites through Supabase Auth (`inviteUserByEmail`).
+ * Delivery (e.g. SendGrid) is configured in Supabase → Authentication → SMTP, not in this file.
+ * See README.md “Staff invites (SendGrid)”.
+ */
+
 export class InviteNotConfiguredError extends Error {
   override name = "InviteNotConfiguredError";
 


### PR DESCRIPTION
- README: SendGrid + Supabase Auth SMTP steps (smtp.sendgrid.net, apikey user)

- .env.example: same checklist; no new API env vars required

- inviteStaff: note that delivery is configured in Supabase dashboard
