### PR TITLE
Release: Stripe billing, funeral director settings, and develop sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,21 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=replace-with-anon-key
 SUPABASE_SERVICE_ROLE_KEY=replace-with-service-role-key
 
+# Staff invitation emails (SendGrid + Supabase — no extra vars here)
+# ------------------------------------------------------------------
+# POST /v1/staff/invite calls supabase.auth.admin.inviteUserByEmail().
+# Supabase sends that email. To use SendGrid:
+#   1) SendGrid: create an API key; verify Sender Identity (single sender or domain auth).
+#   2) Supabase Dashboard → Project Settings → Authentication → SMTP Settings
+#      Enable custom SMTP, for example:
+#        Host: smtp.sendgrid.net
+#        Port: 587
+#        Username: apikey
+#        Password: <your SendGrid API key>
+#        Sender email: your verified from-address in SendGrid
+#        Sender name: Funeralface (or your org)
+#   3) Save. Invites from the app still only need SUPABASE_* on this API; mail goes via SendGrid.
+# See README.md → “Staff invites (SendGrid)”.
+
 # CORS
 ALLOWED_ORIGINS=http://localhost:8010,http://localhost:8080

--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,12 @@ ALLOWED_ORIGINS=http://localhost:8010,http://localhost:8080,http://localhost:517
 
 # API docs (Swagger UI at /docs). Set ENABLE_SWAGGER_UI=false to hide in production.
 # SWAGGER_SERVER_URL=http://localhost:8010
+
+# Stripe subscription — $11.99/month with 7-day trial (create Price in Stripe Dashboard)
+STRIPE_SECRET_KEY=sk_test_replace_me
+STRIPE_WEBHOOK_SECRET=whsec_replace_me
+STRIPE_PRICE_ID=price_replace_me
+# Mobile deep links or HTTPS URLs shown after Checkout / Billing Portal
+STRIPE_CHECKOUT_SUCCESS_URL=everroute://billing/success
+STRIPE_CHECKOUT_CANCEL_URL=everroute://billing/cancel
+STRIPE_PORTAL_RETURN_URL=everroute://billing/portal

--- a/.env.example
+++ b/.env.example
@@ -43,9 +43,11 @@ ALLOWED_ORIGINS=http://localhost:8010,http://localhost:8080,http://localhost:517
 # SWAGGER_SERVER_URL=http://localhost:8010
 
 # Stripe subscription — $11.99/month with 7-day trial (create Price in Stripe Dashboard)
-STRIPE_SECRET_KEY=sk_test_replace_me
-STRIPE_WEBHOOK_SECRET=whsec_replace_me
-STRIPE_PRICE_ID=price_replace_me
+STRIPE_SECRET_KEY=
+# Local: run `stripe listen --forward-to localhost:8010/v1/billing/webhook` and paste the whsec_... here
+# Production: use the signing secret from the Stripe Dashboard webhook destination (not the endpoint URL)
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ID=
 # Mobile deep links or HTTPS URLs shown after Checkout / Billing Portal
 STRIPE_CHECKOUT_SUCCESS_URL=everroute://billing/success
 STRIPE_CHECKOUT_CANCEL_URL=everroute://billing/cancel

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Funeralface Backend
+
+TypeScript Express API for Funeralface. Contract: `openapi.yaml`.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill values.
+2. Install: `npm ci`
+3. Build: `npm run build`
+4. Run migrations: `npm run db:migrate` (requires `DATABASE_URL`)
+5. Dev server: `npm run dev` (default port **8010**)
+
+## Tests
+
+```bash
+npm test
+```
+
+## Staff invites (SendGrid)
+
+Invites from `POST /v1/staff/invite` use **Supabase Auth** `inviteUserByEmail`. Supabase sends the message, so **outbound mail is configured in the Supabase project**, not via new variables in this repo.
+
+### SendGrid
+
+1. In [SendGrid](https://sendgrid.com/), create an **API key** with Mail Send permission.
+2. Complete **Sender Authentication** (recommended: **domain**; minimum: **Single Sender Verification**) so your “from” address is allowed.
+3. In [Supabase Dashboard](https://supabase.com/dashboard) → your project → **Project Settings** → **Authentication** → **SMTP Settings**:
+   - Enable **custom SMTP**
+   - **Host:** `smtp.sendgrid.net`
+   - **Port:** `587`
+   - **Username:** `apikey` (literal string)
+   - **Password:** your SendGrid API key
+   - **Sender email / name:** must match a verified sender in SendGrid
+
+4. Save. Optional: under **Authentication** → **Email Templates**, customize the **Invite user** template.
+
+### This API (Railway, etc.)
+
+Keep **`SUPABASE_URL`** and **`SUPABASE_SERVICE_ROLE_KEY`** set. No SendGrid secrets are required in this service unless you later add direct SendGrid API calls.
+
+Official references: [Supabase custom SMTP](https://supabase.com/docs/guides/auth/auth-smtp), [SendGrid SMTP](https://docs.sendgrid.com/for-developers/sending-email/getting-started-smtp).
+
+## Deploy (Railway)
+
+Uses `Dockerfile` and `railway.toml`. Set the same env vars as production (especially `DATABASE_URL`, `JWT_SECRET`, Supabase keys). Run `npm run db:migrate` against the production database before or after first deploy.

--- a/db/migrations/002_org_billing.sql
+++ b/db/migrations/002_org_billing.sql
@@ -1,0 +1,18 @@
+-- Org-level Stripe subscription state (one row per funeral home / org).
+CREATE TABLE IF NOT EXISTS org_billing (
+  org_id TEXT PRIMARY KEY,
+  stripe_customer_id TEXT UNIQUE,
+  stripe_subscription_id TEXT UNIQUE,
+  status TEXT NOT NULL DEFAULT 'none',
+  trial_ends_at TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT org_billing_status_check
+    CHECK (status IN ('none', 'trialing', 'active', 'past_due', 'canceled', 'unpaid', 'incomplete'))
+);
+
+CREATE INDEX IF NOT EXISTS org_billing_stripe_customer_id_idx
+  ON org_billing(stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;

--- a/db/migrations/003_funeral_director.sql
+++ b/db/migrations/003_funeral_director.sql
@@ -1,0 +1,6 @@
+-- Org-level funeral director contact shown on settings and family communications.
+ALTER TABLE funeral_homes
+  ADD COLUMN IF NOT EXISTS director_name TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS director_phone TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS director_email TEXT,
+  ADD COLUMN IF NOT EXISTS director_image_url TEXT;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -873,8 +873,23 @@ components:
           type: string
     Settings:
       type: object
-      required: [funeral_home_name, funeral_home_phone, funeral_home_address]
+      required:
+        - director_name
+        - director_phone
+        - funeral_home_name
+        - funeral_home_phone
+        - funeral_home_address
       properties:
+        director_name:
+          type: string
+        director_phone:
+          type: string
+        director_email:
+          type: string
+          nullable: true
+        director_image_url:
+          type: string
+          nullable: true
         funeral_home_name:
           type: string
         funeral_home_phone:
@@ -890,6 +905,14 @@ components:
     SettingsUpdateRequest:
       type: object
       properties:
+        director_name:
+          type: string
+        director_phone:
+          type: string
+        director_email:
+          type: string
+        director_image_url:
+          type: string
         funeral_home_name:
           type: string
         funeral_home_phone:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -337,6 +337,83 @@ paths:
           $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+  /v1/billing/subscription:
+    get:
+      tags: [Billing]
+      summary: Get organization subscription status
+      operationId: getBillingSubscription
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Subscription status for the authenticated organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingSubscription'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /v1/billing/checkout-session:
+    post:
+      tags: [Billing]
+      summary: Create Stripe Checkout session (admin)
+      description: Starts subscription checkout with a 7-day trial at $11.99/month.
+      operationId: createBillingCheckoutSession
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Checkout session URL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingCheckoutSession'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '409':
+          description: Organization already subscribed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Billing not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/billing/portal-session:
+    post:
+      tags: [Billing]
+      summary: Create Stripe Customer Portal session (admin)
+      operationId: createBillingPortalSession
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Billing portal URL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingPortalSession'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: No billing customer yet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Billing not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/staff:
     get:
       tags: [Staff]
@@ -823,6 +900,59 @@ components:
           type: string
         default_message:
           type: string
+    BillingSubscription:
+      type: object
+      required:
+        - org_id
+        - status
+        - plan_amount_cents
+        - plan_interval
+        - trial_days
+        - is_subscribed
+        - cancel_at_period_end
+      properties:
+        org_id:
+          type: string
+        status:
+          type: string
+          enum: [none, trialing, active, past_due, canceled, unpaid, incomplete]
+        plan_amount_cents:
+          type: integer
+          example: 1199
+        plan_interval:
+          type: string
+          example: month
+        trial_days:
+          type: integer
+          example: 7
+        trial_ends_at:
+          type: string
+          format: date-time
+          nullable: true
+        current_period_end:
+          type: string
+          format: date-time
+          nullable: true
+        cancel_at_period_end:
+          type: boolean
+        is_subscribed:
+          type: boolean
+    BillingCheckoutSession:
+      type: object
+      required: [checkout_url, session_id]
+      properties:
+        checkout_url:
+          type: string
+          format: uri
+        session_id:
+          type: string
+    BillingPortalSession:
+      type: object
+      required: [portal_url]
+      properties:
+        portal_url:
+          type: string
+          format: uri
     StaffMember:
       type: object
       required: [id, name, phone, active]

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
         "pg": "^8.20.0",
+        "stripe": "^17.7.0",
         "swagger-ui-express": "^5.0.1",
         "yaml": "^2.8.3"
       },
@@ -5563,6 +5564,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/superagent": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "openapi:lint": "spectral lint openapi.yaml",
     "openapi:validate": "swagger-cli validate openapi.yaml",
     "test:contract": "npm run openapi:lint && npm run openapi:validate",
-    "test:api": "node --import tsx --test test/*.test.ts test/auth/*.test.ts test/settings/*.test.ts test/staff/*.test.ts test/assignments/*.test.ts test/public/*.test.ts",
+    "test:api": "node --import tsx --test test/*.test.ts test/auth/*.test.ts test/settings/*.test.ts test/staff/*.test.ts test/assignments/*.test.ts test/public/*.test.ts test/billing/*.test.ts",
     "test:db": "node --import tsx --test test/db/*.test.ts",
     "test": "npm run test:contract && npm run test:db && npm run test:api"
   },
@@ -37,6 +37,7 @@
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",
     "pg": "^8.20.0",
+    "stripe": "^17.7.0",
     "swagger-ui-express": "^5.0.1",
     "yaml": "^2.8.3"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,8 @@ import {
   type StaffInviteService,
 } from "./services/staffInviteService";
 import { defaultStorageUploadService, type StorageUploadService } from "./services/storageUploadService";
+import { defaultBillingService, type BillingService } from "./services/billingService";
+import { postBillingWebhook } from "./controllers/billingWebhookController";
 
 export type AppDependencies = {
   authService?: AuthService;
@@ -28,6 +30,7 @@ export type AppDependencies = {
   assignmentService?: AssignmentService;
   familyTokenService?: FamilyTokenService;
   storageUploadService?: StorageUploadService;
+  billingService?: BillingService;
   /** Override default in-memory rate limit (e.g. tests). */
   publicTokenRateLimit?: RequestHandler;
 };
@@ -57,18 +60,6 @@ export function createApp(deps: AppDependencies = {}): Express {
     next();
   });
 
-  app.use(express.json());
-  app.use((req, res, next) => {
-    const start = process.hrtime.bigint();
-    res.on("finish", () => {
-      const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
-      console.log(
-        `[API] ${req.method} ${req.originalUrl} -> ${res.statusCode} (${durationMs.toFixed(1)}ms)`,
-      );
-    });
-    next();
-  });
-
   const services: AppServices = {
     inviteUserByEmail: deps.inviteUserByEmail ?? (() => Promise.reject(new Error("Invite service is not configured."))),
     authService: deps.authService ?? defaultAuthService,
@@ -77,6 +68,7 @@ export function createApp(deps: AppDependencies = {}): Express {
     assignmentService: deps.assignmentService ?? defaultAssignmentService,
     familyTokenService: deps.familyTokenService ?? defaultFamilyTokenService,
     storageUploadService: deps.storageUploadService ?? defaultStorageUploadService,
+    billingService: deps.billingService ?? defaultBillingService,
     publicTokenRateLimit:
       deps.publicTokenRateLimit ??
       createPublicTokenRateLimit({
@@ -99,6 +91,24 @@ export function createApp(deps: AppDependencies = {}): Express {
       });
     };
   }
+
+  app.post(
+    "/v1/billing/webhook",
+    express.raw({ type: "application/json" }),
+    (req, res) => postBillingWebhook(req, res, services.billingService),
+  );
+
+  app.use(express.json());
+  app.use((req, res, next) => {
+    const start = process.hrtime.bigint();
+    res.on("finish", () => {
+      const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+      console.log(
+        `[API] ${req.method} ${req.originalUrl} -> ${res.statusCode} (${durationMs.toFixed(1)}ms)`,
+      );
+    });
+    next();
+  });
 
   registerV1Routes(app, services);
   setupSwaggerUi(app);

--- a/src/appServices.ts
+++ b/src/appServices.ts
@@ -6,6 +6,7 @@ import type { SettingsService } from "./services/settingsService";
 import type { StaffService } from "./services/staffService";
 import type { StaffInviteService } from "./services/staffInviteService";
 import type { StorageUploadService } from "./services/storageUploadService";
+import type { BillingService } from "./services/billingService";
 import type { InviteByEmailInput } from "./services/inviteStaff";
 
 /** Concrete dependencies after `createApp` applies defaults (used by routes/controllers). */
@@ -18,5 +19,6 @@ export type AppServices = {
   familyTokenService: FamilyTokenService;
   staffInviteService: StaffInviteService;
   storageUploadService: StorageUploadService;
+  billingService: BillingService;
   publicTokenRateLimit: RequestHandler;
 };

--- a/src/controllers/assignmentController.ts
+++ b/src/controllers/assignmentController.ts
@@ -7,6 +7,8 @@ import {
   type AssignmentStatus,
   type AssignmentUpdateInput,
 } from "../services/assignmentService";
+import type { BillingService } from "../services/billingService";
+import { SubscriptionRequiredError } from "../services/billingService";
 import { FamilyLinkNotConfiguredError, isValidEmail, sendFamilyLinkByEmail } from "../services/inviteStaff";
 import { parseEtaTimeFromBody, serializeAssignmentEtaTime } from "../utils/etaTime";
 
@@ -98,10 +100,18 @@ export async function postAssignment(
   res.status(201).json(serializeAssignmentResponse(created));
 }
 
+function respondsSubscriptionRequired(res: Response, error: SubscriptionRequiredError): void {
+  res.status(403).json({
+    code: error.code,
+    message: error.message,
+  });
+}
+
 export async function patchAssignment(
   req: AuthenticatedRequest,
   res: Response,
   assignmentService: AssignmentService,
+  billingService: BillingService,
 ): Promise<void> {
   const orgId = req.auth?.orgId;
   const actorUserId = req.auth?.userId;
@@ -173,7 +183,16 @@ export async function patchAssignment(
     return;
   }
 
+  const issuingFamilyLink =
+    update.share_token !== undefined &&
+    update.share_token !== null &&
+    update.share_token.length > 0;
+
   try {
+    if (issuingFamilyLink) {
+      await billingService.assertOrgCanShareFamilyLinks(orgId);
+    }
+
     const updated = await assignmentService.updateByOrgIdAndId(orgId, id, update, actorUserId);
     if (!updated) {
       res.status(404).json({
@@ -198,6 +217,10 @@ export async function patchAssignment(
       });
       return;
     }
+    if (error instanceof SubscriptionRequiredError) {
+      respondsSubscriptionRequired(res, error);
+      return;
+    }
     throw error;
   }
 }
@@ -206,6 +229,7 @@ export async function postShareFamilyLinkByEmail(
   req: AuthenticatedRequest,
   res: Response,
   assignmentService: AssignmentService,
+  billingService: BillingService,
 ): Promise<void> {
   const orgId = req.auth?.orgId;
   if (!orgId) {
@@ -258,6 +282,8 @@ export async function postShareFamilyLinkByEmail(
   const familyLink = `${familyLinkBaseUrl}/family/${encodeURIComponent(assignment.share_token)}`;
 
   try {
+    await billingService.assertOrgCanShareFamilyLinks(orgId);
+
     await sendFamilyLinkByEmail({
       email,
       familyLink,
@@ -271,6 +297,10 @@ export async function postShareFamilyLinkByEmail(
     });
     res.status(202).json({ ok: true });
   } catch (error) {
+    if (error instanceof SubscriptionRequiredError) {
+      respondsSubscriptionRequired(res, error);
+      return;
+    }
     if (error instanceof FamilyLinkNotConfiguredError) {
       res.status(503).json({
         code: "family_link_not_configured",

--- a/src/controllers/billingController.ts
+++ b/src/controllers/billingController.ts
@@ -1,0 +1,114 @@
+import type { Response } from "express";
+import type { AuthenticatedRequest } from "../auth/authMiddleware";
+import type { BillingService } from "../services/billingService";
+
+function checkoutUrls(): { successUrl: string; cancelUrl: string } | null {
+  const successUrl = process.env.STRIPE_CHECKOUT_SUCCESS_URL?.trim();
+  const cancelUrl = process.env.STRIPE_CHECKOUT_CANCEL_URL?.trim();
+  if (!successUrl || !cancelUrl) return null;
+  return { successUrl, cancelUrl };
+}
+
+function portalReturnUrl(): string | null {
+  return process.env.STRIPE_PORTAL_RETURN_URL?.trim() || null;
+}
+
+export async function getSubscription(
+  req: AuthenticatedRequest,
+  res: Response,
+  billingService: BillingService,
+): Promise<void> {
+  const orgId = req.auth?.orgId;
+  if (!orgId) {
+    res.status(401).json({ code: "unauthorized", message: "Authentication is required." });
+    return;
+  }
+
+  const view = await billingService.getSubscriptionView(orgId);
+  res.status(200).json(view);
+}
+
+export async function postCheckoutSession(
+  req: AuthenticatedRequest,
+  res: Response,
+  billingService: BillingService,
+): Promise<void> {
+  const orgId = req.auth?.orgId;
+  if (!orgId) {
+    res.status(401).json({ code: "unauthorized", message: "Authentication is required." });
+    return;
+  }
+
+  const urls = checkoutUrls();
+  if (!urls) {
+    res.status(503).json({
+      code: "billing_not_configured",
+      message: "Checkout URLs are not configured on the server.",
+    });
+    return;
+  }
+
+  try {
+    const session = await billingService.createCheckoutSession({
+      orgId,
+      customerEmail: req.auth?.email,
+      successUrl: urls.successUrl,
+      cancelUrl: urls.cancelUrl,
+    });
+    res.status(200).json(session);
+  } catch (error) {
+    const code = (error as Error & { code?: string }).code;
+    if (code === "subscription_exists") {
+      res.status(409).json({
+        code: "subscription_exists",
+        message: "This organization already has an active subscription.",
+      });
+      return;
+    }
+    console.error("[billing] checkout session failed:", error);
+    res.status(500).json({
+      code: "billing_error",
+      message: "Unable to start checkout. Please try again.",
+    });
+  }
+}
+
+export async function postPortalSession(
+  req: AuthenticatedRequest,
+  res: Response,
+  billingService: BillingService,
+): Promise<void> {
+  const orgId = req.auth?.orgId;
+  if (!orgId) {
+    res.status(401).json({ code: "unauthorized", message: "Authentication is required." });
+    return;
+  }
+
+  const returnUrl = portalReturnUrl();
+  if (!returnUrl) {
+    res.status(503).json({
+      code: "billing_not_configured",
+      message: "Billing portal return URL is not configured on the server.",
+    });
+    return;
+  }
+
+  try {
+    const session = await billingService.createPortalSession({ orgId, returnUrl });
+    res.status(200).json(session);
+  } catch (error) {
+    const code = (error as Error & { code?: string }).code;
+    if (code === "billing_customer_missing") {
+      res.status(404).json({
+        code: "billing_customer_missing",
+        message: "Subscribe first before managing billing.",
+      });
+      return;
+    }
+    console.error("[billing] portal session failed:", error);
+    res.status(500).json({
+      code: "billing_error",
+      message: "Unable to open billing portal. Please try again.",
+    });
+  }
+}

--- a/src/controllers/billingWebhookController.ts
+++ b/src/controllers/billingWebhookController.ts
@@ -26,6 +26,7 @@ export async function postBillingWebhook(
 
   try {
     await billingService.handleWebhookEvent(rawBody, signature);
+    console.log("[billing] webhook handled successfully");
     res.status(200).json({ received: true });
   } catch (error) {
     console.error("[billing] webhook failed:", error);

--- a/src/controllers/billingWebhookController.ts
+++ b/src/controllers/billingWebhookController.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from "express";
+import type { BillingService } from "../services/billingService";
+
+export async function postBillingWebhook(
+  req: Request,
+  res: Response,
+  billingService: BillingService,
+): Promise<void> {
+  const signature = req.headers["stripe-signature"];
+  if (!signature || typeof signature !== "string") {
+    res.status(400).json({
+      code: "invalid_request",
+      message: "Missing Stripe-Signature header.",
+    });
+    return;
+  }
+
+  const rawBody = req.body;
+  if (!Buffer.isBuffer(rawBody)) {
+    res.status(400).json({
+      code: "invalid_request",
+      message: "Webhook body must be raw bytes.",
+    });
+    return;
+  }
+
+  try {
+    await billingService.handleWebhookEvent(rawBody, signature);
+    res.status(200).json({ received: true });
+  } catch (error) {
+    console.error("[billing] webhook failed:", error);
+    res.status(400).json({
+      code: "webhook_error",
+      message: "Webhook signature verification or processing failed.",
+    });
+  }
+}

--- a/src/controllers/settingsController.ts
+++ b/src/controllers/settingsController.ts
@@ -35,7 +35,18 @@ export async function patchSettings(
   }
 
   const body = req.body as Record<string, unknown>;
+  const nullableStringKeys = new Set<keyof SettingsUpdateInput>([
+    "director_email",
+    "director_image_url",
+    "logo_url",
+    "default_message",
+  ]);
+
   const allowedKeys: (keyof SettingsUpdateInput)[] = [
+    "director_name",
+    "director_phone",
+    "director_email",
+    "director_image_url",
     "funeral_home_name",
     "funeral_home_phone",
     "funeral_home_address",
@@ -48,13 +59,29 @@ export async function patchSettings(
     const value = body[key];
     if (typeof value === "string") {
       const normalized = value.trim();
-      if ((key === "logo_url" || key === "default_message") && normalized.length === 0) {
-        update[key] = null;
+      if (nullableStringKeys.has(key)) {
+        const nullableKey = key as
+          | "director_email"
+          | "director_image_url"
+          | "logo_url"
+          | "default_message";
+        update[nullableKey] = normalized.length === 0 ? null : normalized;
       } else {
-        update[key] = normalized;
+        const requiredKey = key as
+          | "director_name"
+          | "director_phone"
+          | "funeral_home_name"
+          | "funeral_home_phone"
+          | "funeral_home_address";
+        update[requiredKey] = normalized;
       }
-    } else if ((key === "logo_url" || key === "default_message") && value === null) {
-      update[key] = null;
+    } else if (nullableStringKeys.has(key) && value === null) {
+      const nullableKey = key as
+        | "director_email"
+        | "director_image_url"
+        | "logo_url"
+        | "default_message";
+      update[nullableKey] = null;
     }
   }
 

--- a/src/controllers/uploadController.ts
+++ b/src/controllers/uploadController.ts
@@ -2,7 +2,11 @@ import type { Response } from "express";
 import type { AuthenticatedRequest } from "../auth/authMiddleware";
 import type { StorageUploadService, UploadPurpose } from "../services/storageUploadService";
 
-const ALLOWED_PURPOSES: UploadPurpose[] = ["funeral_home_logo", "staff_photo"];
+const ALLOWED_PURPOSES: UploadPurpose[] = [
+  "funeral_home_logo",
+  "funeral_director_photo",
+  "staff_photo",
+];
 const ALLOWED_PURPOSE_SET = new Set<UploadPurpose>(ALLOWED_PURPOSES);
 const ALLOWED_MIME_TYPES = new Set([
   "image/png",
@@ -62,7 +66,8 @@ export async function postUploadImage(
   if (!purpose) {
     res.status(400).json({
       code: "bad_request",
-      message: "purpose must be one of: funeral_home_logo, staff_photo.",
+      message:
+        "purpose must be one of: funeral_home_logo, funeral_director_photo, staff_photo.",
     });
     return;
   }

--- a/src/routes/assignmentRoutes.ts
+++ b/src/routes/assignmentRoutes.ts
@@ -21,11 +21,21 @@ export function createAssignmentRouter(services: AppServices): Router {
   );
 
   router.patch("/:id", requireAuth, (req: Request, res: Response) =>
-    patchAssignment(req as AuthenticatedRequest, res, services.assignmentService),
+    patchAssignment(
+      req as AuthenticatedRequest,
+      res,
+      services.assignmentService,
+      services.billingService,
+    ),
   );
 
   router.post("/:id/share/email", requireAuth, (req: Request, res: Response) =>
-    postShareFamilyLinkByEmail(req as AuthenticatedRequest, res, services.assignmentService),
+    postShareFamilyLinkByEmail(
+      req as AuthenticatedRequest,
+      res,
+      services.assignmentService,
+      services.billingService,
+    ),
   );
 
   return router;

--- a/src/routes/billingRoutes.ts
+++ b/src/routes/billingRoutes.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { requireAuth, type AuthenticatedRequest } from "../auth/authMiddleware";
+import { requireRole } from "../auth/requireRole";
+import type { AppServices } from "../appServices";
+import {
+  getSubscription,
+  postCheckoutSession,
+  postPortalSession,
+} from "../controllers/billingController";
+
+export function createBillingRouter(services: AppServices): Router {
+  const router = Router();
+
+  router.get("/subscription", requireAuth, (req: Request, res: Response) =>
+    getSubscription(req as AuthenticatedRequest, res, services.billingService),
+  );
+
+  router.post(
+    "/checkout-session",
+    requireAuth,
+    requireRole("admin"),
+    (req: Request, res: Response) =>
+      postCheckoutSession(req as AuthenticatedRequest, res, services.billingService),
+  );
+
+  router.post(
+    "/portal-session",
+    requireAuth,
+    requireRole("admin"),
+    (req: Request, res: Response) =>
+      postPortalSession(req as AuthenticatedRequest, res, services.billingService),
+  );
+
+  return router;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,11 +7,13 @@ import { createPublicRouter } from "./publicRoutes";
 import { createSettingsRouter } from "./settingsRoutes";
 import { createStaffRouter } from "./staffRoutes";
 import { createUploadRouter } from "./uploadRoutes";
+import { createBillingRouter } from "./billingRoutes";
 
 export function registerV1Routes(app: Express, services: AppServices): void {
   app.use("/v1", createHealthRouter());
   app.use("/v1/auth", createAuthRouter(services));
   app.use("/v1/settings", createSettingsRouter(services));
+  app.use("/v1/billing", createBillingRouter(services));
   app.use("/v1/uploads", createUploadRouter(services));
   app.use("/v1/staff", createStaffRouter(services));
   app.use("/v1/assignments", createAssignmentRouter(services));

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -36,8 +36,27 @@ export type SubscriptionView = {
   is_subscribed: boolean;
 };
 
+export class SubscriptionRequiredError extends Error {
+  override readonly name = "SubscriptionRequiredError";
+
+  readonly code = "subscription_required";
+
+  constructor(
+    message = "An active subscription is required to share family links. Subscribe in Settings → Payment.",
+  ) {
+    super(message);
+  }
+}
+
+export function assertOrgCanShareFamilyLinks(view: SubscriptionView): void {
+  if (!view.is_subscribed) {
+    throw new SubscriptionRequiredError();
+  }
+}
+
 export type BillingService = {
   getSubscriptionView: (orgId: string) => Promise<SubscriptionView>;
+  assertOrgCanShareFamilyLinks: (orgId: string) => Promise<void>;
   createCheckoutSession: (input: {
     orgId: string;
     customerEmail?: string;
@@ -253,10 +272,43 @@ async function resolveOrgIdFromSubscription(
   return (byCustomer.rows[0]?.org_id as string | undefined) ?? null;
 }
 
+/** Pull latest trialing/active subscription from Stripe when webhooks did not update the DB. */
+async function syncSubscriptionFromStripeIfNeeded(
+  orgId: string,
+  record: OrgBillingRecord,
+): Promise<OrgBillingRecord> {
+  if (!record.stripe_customer_id) return record;
+  if (record.status === "trialing" || record.status === "active") return record;
+
+  try {
+    const stripe = getStripe();
+    const listed = await stripe.subscriptions.list({
+      customer: record.stripe_customer_id,
+      status: "all",
+      limit: 10,
+    });
+    const match = listed.data.find(
+      (sub) => sub.status === "trialing" || sub.status === "active",
+    );
+    if (!match) return record;
+
+    return await upsertFromStripeSubscription(orgId, match, record.stripe_customer_id);
+  } catch (error) {
+    console.warn("[billing] Stripe subscription sync failed:", error);
+    return record;
+  }
+}
+
 export const defaultBillingService: BillingService = {
   async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
-    const record = await getOrCreateBillingRow(orgId);
+    const initial = await getOrCreateBillingRow(orgId);
+    const record = await syncSubscriptionFromStripeIfNeeded(orgId, initial);
     return toSubscriptionView(record);
+  },
+
+  async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
+    const view = await this.getSubscriptionView(orgId);
+    assertOrgCanShareFamilyLinks(view);
   },
 
   async createCheckoutSession(input) {
@@ -339,6 +391,7 @@ export const defaultBillingService: BillingService = {
     }
 
     const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+    console.log(`[billing] webhook received: ${event.type} (${event.id})`);
 
     switch (event.type) {
       case "checkout.session.completed": {
@@ -359,6 +412,7 @@ export const defaultBillingService: BillingService = {
             ? session.customer
             : session.customer?.id ?? null;
         await upsertFromStripeSubscription(orgId, subscription, customerId);
+        console.log(`[billing] synced checkout subscription for org ${orgId}`);
         break;
       }
       case "customer.subscription.created":

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -1,0 +1,396 @@
+import { Pool } from "pg";
+import Stripe from "stripe";
+
+export const BILLING_PLAN_AMOUNT_CENTS = 1199;
+export const BILLING_TRIAL_DAYS = 7;
+export const BILLING_PLAN_INTERVAL = "month" as const;
+
+export type BillingStatus =
+  | "none"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "unpaid"
+  | "incomplete";
+
+export type OrgBillingRecord = {
+  org_id: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  status: BillingStatus;
+  trial_ends_at: string | null;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+};
+
+export type SubscriptionView = {
+  org_id: string;
+  status: BillingStatus;
+  plan_amount_cents: number;
+  plan_interval: typeof BILLING_PLAN_INTERVAL;
+  trial_days: number;
+  trial_ends_at: string | null;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+  is_subscribed: boolean;
+};
+
+export type BillingService = {
+  getSubscriptionView: (orgId: string) => Promise<SubscriptionView>;
+  createCheckoutSession: (input: {
+    orgId: string;
+    customerEmail?: string;
+    successUrl: string;
+    cancelUrl: string;
+  }) => Promise<{ checkout_url: string; session_id: string }>;
+  createPortalSession: (input: {
+    orgId: string;
+    returnUrl: string;
+  }) => Promise<{ portal_url: string }>;
+  handleWebhookEvent: (rawBody: Buffer, signature: string) => Promise<void>;
+};
+
+let pgPool: Pool | null = null;
+
+function getPgPool(): Pool {
+  if (pgPool) return pgPool;
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for billing service.");
+  }
+  pgPool = new Pool({ connectionString });
+  return pgPool;
+}
+
+function getStripe(): Stripe {
+  const secret = process.env.STRIPE_SECRET_KEY?.trim();
+  if (!secret) {
+    throw new Error("STRIPE_SECRET_KEY is required for billing.");
+  }
+  return new Stripe(secret);
+}
+
+function toIso(value: Date | null | undefined): string | null {
+  if (!value) return null;
+  return value.toISOString();
+}
+
+function mapStripeSubscriptionStatus(status: Stripe.Subscription.Status): BillingStatus {
+  switch (status) {
+    case "trialing":
+      return "trialing";
+    case "active":
+      return "active";
+    case "past_due":
+      return "past_due";
+    case "canceled":
+      return "canceled";
+    case "unpaid":
+      return "unpaid";
+    case "incomplete":
+    case "incomplete_expired":
+      return "incomplete";
+    default:
+      return "none";
+  }
+}
+
+function rowToRecord(row: {
+  org_id: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  status: string;
+  trial_ends_at: Date | null;
+  current_period_end: Date | null;
+  cancel_at_period_end: boolean;
+}): OrgBillingRecord {
+  return {
+    org_id: row.org_id,
+    stripe_customer_id: row.stripe_customer_id,
+    stripe_subscription_id: row.stripe_subscription_id,
+    status: row.status as BillingStatus,
+    trial_ends_at: toIso(row.trial_ends_at),
+    current_period_end: toIso(row.current_period_end),
+    cancel_at_period_end: row.cancel_at_period_end,
+  };
+}
+
+function toSubscriptionView(record: OrgBillingRecord): SubscriptionView {
+  const subscribed = record.status === "trialing" || record.status === "active";
+  return {
+    org_id: record.org_id,
+    status: record.status,
+    plan_amount_cents: BILLING_PLAN_AMOUNT_CENTS,
+    plan_interval: BILLING_PLAN_INTERVAL,
+    trial_days: BILLING_TRIAL_DAYS,
+    trial_ends_at: record.trial_ends_at,
+    current_period_end: record.current_period_end,
+    cancel_at_period_end: record.cancel_at_period_end,
+    is_subscribed: subscribed,
+  };
+}
+
+async function getOrCreateBillingRow(orgId: string): Promise<OrgBillingRecord> {
+  const pool = getPgPool();
+  const existing = await pool.query(
+    `
+    SELECT org_id, stripe_customer_id, stripe_subscription_id, status,
+           trial_ends_at, current_period_end, cancel_at_period_end
+    FROM org_billing
+    WHERE org_id = $1
+    LIMIT 1
+    `,
+    [orgId],
+  );
+  if (existing.rows[0]) {
+    return rowToRecord(existing.rows[0]);
+  }
+
+  const inserted = await pool.query(
+    `
+    INSERT INTO org_billing (org_id, status)
+    VALUES ($1, 'none')
+    ON CONFLICT (org_id) DO NOTHING
+    RETURNING org_id, stripe_customer_id, stripe_subscription_id, status,
+              trial_ends_at, current_period_end, cancel_at_period_end
+    `,
+    [orgId],
+  );
+  if (inserted.rows[0]) {
+    return rowToRecord(inserted.rows[0]);
+  }
+
+  const again = await pool.query(
+    `
+    SELECT org_id, stripe_customer_id, stripe_subscription_id, status,
+           trial_ends_at, current_period_end, cancel_at_period_end
+    FROM org_billing
+    WHERE org_id = $1
+    LIMIT 1
+    `,
+    [orgId],
+  );
+  return rowToRecord(again.rows[0]);
+}
+
+async function upsertFromStripeSubscription(
+  orgId: string,
+  subscription: Stripe.Subscription,
+  customerId: string | null,
+): Promise<OrgBillingRecord> {
+  const pool = getPgPool();
+  const status = mapStripeSubscriptionStatus(subscription.status);
+  const trialEnd = subscription.trial_end
+    ? new Date(subscription.trial_end * 1000)
+    : null;
+  const periodEnd = subscription.current_period_end
+    ? new Date(subscription.current_period_end * 1000)
+    : null;
+
+  const result = await pool.query(
+    `
+    INSERT INTO org_billing (
+      org_id,
+      stripe_customer_id,
+      stripe_subscription_id,
+      status,
+      trial_ends_at,
+      current_period_end,
+      cancel_at_period_end
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
+    ON CONFLICT (org_id)
+    DO UPDATE SET
+      stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, org_billing.stripe_customer_id),
+      stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+      status = EXCLUDED.status,
+      trial_ends_at = EXCLUDED.trial_ends_at,
+      current_period_end = EXCLUDED.current_period_end,
+      cancel_at_period_end = EXCLUDED.cancel_at_period_end,
+      updated_at = NOW()
+    RETURNING org_id, stripe_customer_id, stripe_subscription_id, status,
+              trial_ends_at, current_period_end, cancel_at_period_end
+    `,
+    [
+      orgId,
+      customerId,
+      subscription.id,
+      status,
+      trialEnd,
+      periodEnd,
+      subscription.cancel_at_period_end,
+    ],
+  );
+  return rowToRecord(result.rows[0]);
+}
+
+async function resolveOrgIdFromSubscription(
+  subscription: Stripe.Subscription,
+): Promise<string | null> {
+  const metaOrg = subscription.metadata?.org_id?.trim();
+  if (metaOrg) return metaOrg;
+
+  const pool = getPgPool();
+  const bySub = await pool.query(
+    `SELECT org_id FROM org_billing WHERE stripe_subscription_id = $1 LIMIT 1`,
+    [subscription.id],
+  );
+  if (bySub.rows[0]?.org_id) {
+    return bySub.rows[0].org_id as string;
+  }
+
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer?.id;
+  if (!customerId) return null;
+
+  const byCustomer = await pool.query(
+    `SELECT org_id FROM org_billing WHERE stripe_customer_id = $1 LIMIT 1`,
+    [customerId],
+  );
+  return (byCustomer.rows[0]?.org_id as string | undefined) ?? null;
+}
+
+export const defaultBillingService: BillingService = {
+  async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
+    const record = await getOrCreateBillingRow(orgId);
+    return toSubscriptionView(record);
+  },
+
+  async createCheckoutSession(input) {
+    const stripe = getStripe();
+    const priceId = process.env.STRIPE_PRICE_ID?.trim();
+    if (!priceId) {
+      throw new Error("STRIPE_PRICE_ID is required for checkout.");
+    }
+
+    const record = await getOrCreateBillingRow(input.orgId);
+    if (record.status === "trialing" || record.status === "active") {
+      const error = new Error("Organization already has an active subscription.");
+      (error as Error & { code?: string }).code = "subscription_exists";
+      throw error;
+    }
+
+    let customerId = record.stripe_customer_id;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: input.customerEmail?.trim() || undefined,
+        metadata: { org_id: input.orgId },
+      });
+      customerId = customer.id;
+      const pool = getPgPool();
+      await pool.query(
+        `
+        INSERT INTO org_billing (org_id, stripe_customer_id, status)
+        VALUES ($1, $2, 'none')
+        ON CONFLICT (org_id)
+        DO UPDATE SET stripe_customer_id = EXCLUDED.stripe_customer_id, updated_at = NOW()
+        `,
+        [input.orgId, customerId],
+      );
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      subscription_data: {
+        trial_period_days: BILLING_TRIAL_DAYS,
+        metadata: { org_id: input.orgId },
+      },
+      client_reference_id: input.orgId,
+      metadata: { org_id: input.orgId },
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+      allow_promotion_codes: false,
+    });
+
+    if (!session.url) {
+      throw new Error("Stripe checkout session did not return a URL.");
+    }
+
+    return { checkout_url: session.url, session_id: session.id };
+  },
+
+  async createPortalSession(input) {
+    const stripe = getStripe();
+    const record = await getOrCreateBillingRow(input.orgId);
+    if (!record.stripe_customer_id) {
+      const error = new Error("No billing customer exists for this organization.");
+      (error as Error & { code?: string }).code = "billing_customer_missing";
+      throw error;
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: record.stripe_customer_id,
+      return_url: input.returnUrl,
+    });
+
+    return { portal_url: session.url };
+  },
+
+  async handleWebhookEvent(rawBody, signature) {
+    const stripe = getStripe();
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
+    if (!webhookSecret) {
+      throw new Error("STRIPE_WEBHOOK_SECRET is required for webhooks.");
+    }
+
+    const event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const orgId =
+          session.metadata?.org_id?.trim() ||
+          session.client_reference_id?.trim() ||
+          null;
+        if (!orgId || !session.subscription) break;
+
+        const subscriptionId =
+          typeof session.subscription === "string"
+            ? session.subscription
+            : session.subscription.id;
+        const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+        const customerId =
+          typeof session.customer === "string"
+            ? session.customer
+            : session.customer?.id ?? null;
+        await upsertFromStripeSubscription(orgId, subscription, customerId);
+        break;
+      }
+      case "customer.subscription.created":
+      case "customer.subscription.updated":
+      case "customer.subscription.deleted": {
+        const subscription = event.data.object as Stripe.Subscription;
+        const orgId = await resolveOrgIdFromSubscription(subscription);
+        if (!orgId) break;
+        const customerId =
+          typeof subscription.customer === "string"
+            ? subscription.customer
+            : subscription.customer?.id ?? null;
+        if (event.type === "customer.subscription.deleted") {
+          const pool = getPgPool();
+          await pool.query(
+            `
+            UPDATE org_billing
+            SET status = 'canceled',
+                stripe_subscription_id = NULL,
+                cancel_at_period_end = false,
+                updated_at = NOW()
+            WHERE org_id = $1
+            `,
+            [orgId],
+          );
+        } else {
+          await upsertFromStripeSubscription(orgId, subscription, customerId);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  },
+};

--- a/src/services/inviteStaff.ts
+++ b/src/services/inviteStaff.ts
@@ -1,5 +1,11 @@
 import { createClient } from "@supabase/supabase-js";
 
+/**
+ * Sends staff invites through Supabase Auth (`inviteUserByEmail`).
+ * Delivery (e.g. SendGrid) is configured in Supabase → Authentication → SMTP, not in this file.
+ * See README.md “Staff invites (SendGrid)”.
+ */
+
 export class InviteNotConfiguredError extends Error {
   override name = "InviteNotConfiguredError";
 

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -2,6 +2,10 @@ import { Pool } from "pg";
 
 export type SettingsRecord = {
   org_id: string;
+  director_name: string;
+  director_phone: string;
+  director_email: string | null;
+  director_image_url: string | null;
   funeral_home_name: string;
   funeral_home_phone: string;
   funeral_home_address: string;
@@ -9,7 +13,17 @@ export type SettingsRecord = {
   default_message: string | null;
 };
 
-export type SettingsUpdateInput = Partial<Omit<SettingsRecord, "org_id">>;
+export type SettingsUpdateInput = {
+  director_name?: string;
+  director_phone?: string;
+  director_email?: string | null;
+  director_image_url?: string | null;
+  funeral_home_name?: string;
+  funeral_home_phone?: string;
+  funeral_home_address?: string;
+  logo_url?: string | null;
+  default_message?: string | null;
+};
 
 export type SettingsService = {
   getByOrgId: (orgId: string) => Promise<SettingsRecord>;
@@ -17,6 +31,10 @@ export type SettingsService = {
 };
 
 const DEFAULT_SETTINGS = {
+  director_name: "",
+  director_phone: "",
+  director_email: null,
+  director_image_url: null,
   funeral_home_name: "",
   funeral_home_phone: "",
   funeral_home_address: "",
@@ -45,6 +63,10 @@ export const defaultSettingsService: SettingsService = {
       `
       SELECT
         id AS org_id,
+        director_name,
+        director_phone,
+        director_email,
+        director_image_url,
         funeral_home_name,
         funeral_home_phone,
         funeral_home_address,
@@ -78,6 +100,10 @@ export const defaultSettingsService: SettingsService = {
       `
       INSERT INTO funeral_homes (
         id,
+        director_name,
+        director_phone,
+        director_email,
+        director_image_url,
         funeral_home_name,
         funeral_home_phone,
         funeral_home_address,
@@ -90,10 +116,18 @@ export const defaultSettingsService: SettingsService = {
         $3,
         $4,
         $5,
-        $6
+        $6,
+        $7,
+        $8,
+        $9,
+        $10
       )
       ON CONFLICT (id)
       DO UPDATE SET
+        director_name = EXCLUDED.director_name,
+        director_phone = EXCLUDED.director_phone,
+        director_email = EXCLUDED.director_email,
+        director_image_url = EXCLUDED.director_image_url,
         funeral_home_name = EXCLUDED.funeral_home_name,
         funeral_home_phone = EXCLUDED.funeral_home_phone,
         funeral_home_address = EXCLUDED.funeral_home_address,
@@ -102,6 +136,10 @@ export const defaultSettingsService: SettingsService = {
         updated_at = NOW()
       RETURNING
         id AS org_id,
+        director_name,
+        director_phone,
+        director_email,
+        director_image_url,
         funeral_home_name,
         funeral_home_phone,
         funeral_home_address,
@@ -110,6 +148,10 @@ export const defaultSettingsService: SettingsService = {
       `,
       [
         orgId,
+        next.director_name,
+        next.director_phone,
+        next.director_email,
+        next.director_image_url,
         next.funeral_home_name,
         next.funeral_home_phone,
         next.funeral_home_address,
@@ -121,4 +163,3 @@ export const defaultSettingsService: SettingsService = {
     return result.rows[0];
   },
 };
-

--- a/src/services/storageUploadService.ts
+++ b/src/services/storageUploadService.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-export type UploadPurpose = "funeral_home_logo" | "staff_photo";
+export type UploadPurpose = "funeral_home_logo" | "funeral_director_photo" | "staff_photo";
 
 export type UploadImageInput = {
   orgId: string;
@@ -56,6 +56,7 @@ function sanitizePathPart(value: string): string {
 
 function pathSegmentForPurpose(purpose: UploadPurpose): string {
   if (purpose === "staff_photo") return "staff";
+  if (purpose === "funeral_director_photo") return "directors";
   return "logos";
 }
 

--- a/test/billing/billing.test.ts
+++ b/test/billing/billing.test.ts
@@ -4,6 +4,7 @@ import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
 import {
+  assertOrgCanShareFamilyLinks,
   BILLING_PLAN_AMOUNT_CENTS,
   BILLING_TRIAL_DAYS,
   type BillingService,
@@ -34,6 +35,11 @@ function createInMemoryBillingService(): BillingService {
   return {
     async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
       return store.get(orgId) ?? defaultView(orgId);
+    },
+
+    async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
+      const view = await this.getSubscriptionView(orgId);
+      assertOrgCanShareFamilyLinks(view);
     },
 
     async createCheckoutSession(input) {

--- a/test/billing/billing.test.ts
+++ b/test/billing/billing.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { createApp } from "../../src/app";
+import {
+  BILLING_PLAN_AMOUNT_CENTS,
+  BILLING_TRIAL_DAYS,
+  type BillingService,
+  type SubscriptionView,
+} from "../../src/services/billingService";
+
+const JWT_SECRET = "test-secret-billing";
+
+function makeToken(orgId: string, role = "admin"): string {
+  return jwt.sign({ sub: "user-1", role, org_id: orgId }, JWT_SECRET);
+}
+
+function createInMemoryBillingService(): BillingService {
+  const store = new Map<string, SubscriptionView>();
+
+  const defaultView = (orgId: string): SubscriptionView => ({
+    org_id: orgId,
+    status: "none",
+    plan_amount_cents: BILLING_PLAN_AMOUNT_CENTS,
+    plan_interval: "month",
+    trial_days: BILLING_TRIAL_DAYS,
+    trial_ends_at: null,
+    current_period_end: null,
+    cancel_at_period_end: false,
+    is_subscribed: false,
+  });
+
+  return {
+    async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
+      return store.get(orgId) ?? defaultView(orgId);
+    },
+
+    async createCheckoutSession(input) {
+      const current = await this.getSubscriptionView(input.orgId);
+      if (current.is_subscribed) {
+        const error = new Error("already subscribed");
+        (error as Error & { code?: string }).code = "subscription_exists";
+        throw error;
+      }
+      return {
+        checkout_url: "https://checkout.stripe.test/session",
+        session_id: "cs_test_123",
+      };
+    },
+
+    async createPortalSession(input) {
+      const current = await this.getSubscriptionView(input.orgId);
+      if (current.status === "none") {
+        const error = new Error("missing customer");
+        (error as Error & { code?: string }).code = "billing_customer_missing";
+        throw error;
+      }
+      return { portal_url: "https://billing.stripe.test/portal" };
+    },
+
+    async handleWebhookEvent() {
+      // no-op for API tests
+    },
+  };
+}
+
+test.before(() => {
+  process.env.JWT_SECRET = JWT_SECRET;
+  process.env.STRIPE_CHECKOUT_SUCCESS_URL = "everroute://billing/success";
+  process.env.STRIPE_CHECKOUT_CANCEL_URL = "everroute://billing/cancel";
+  process.env.STRIPE_PORTAL_RETURN_URL = "everroute://billing/portal";
+});
+
+test("GET /v1/billing/subscription returns plan details", async () => {
+  const billingService = createInMemoryBillingService();
+  const app = createApp({ billingService });
+  const response = await request(app)
+    .get("/v1/billing/subscription")
+    .set("Authorization", `Bearer ${makeToken("org-bill-1")}`);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.plan_amount_cents, 1199);
+  assert.equal(response.body.trial_days, 7);
+  assert.equal(response.body.status, "none");
+  assert.equal(response.body.is_subscribed, false);
+});
+
+test("POST /v1/billing/checkout-session requires admin", async () => {
+  const billingService = createInMemoryBillingService();
+  const app = createApp({ billingService });
+
+  const forbidden = await request(app)
+    .post("/v1/billing/checkout-session")
+    .set("Authorization", `Bearer ${makeToken("org-bill-2", "user")}`);
+  assert.equal(forbidden.status, 403);
+
+  const ok = await request(app)
+    .post("/v1/billing/checkout-session")
+    .set("Authorization", `Bearer ${makeToken("org-bill-2", "admin")}`);
+  assert.equal(ok.status, 200);
+  assert.ok(ok.body.checkout_url);
+});
+
+test("POST /v1/billing/portal-session returns 404 without customer", async () => {
+  const billingService = createInMemoryBillingService();
+  const app = createApp({ billingService });
+  const response = await request(app)
+    .post("/v1/billing/portal-session")
+    .set("Authorization", `Bearer ${makeToken("org-bill-3", "admin")}`);
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.code, "billing_customer_missing");
+});

--- a/test/settings/settings.test.ts
+++ b/test/settings/settings.test.ts
@@ -19,6 +19,10 @@ function createInMemorySettingsService(): SettingsService {
       return (
         store.get(orgId) ?? {
           org_id: orgId,
+          director_name: "",
+          director_phone: "",
+          director_email: null,
+          director_image_url: null,
           funeral_home_name: "",
           funeral_home_phone: "",
           funeral_home_address: "",
@@ -94,5 +98,26 @@ test("PATCH /v1/settings returns 400 for invalid payload", async () => {
 
   assert.equal(response.status, 400);
   assert.equal(response.body.code, "bad_request");
+});
+
+test("PATCH /v1/settings updates funeral director fields", async () => {
+  const settingsService = createInMemorySettingsService();
+  const app = createApp({ settingsService });
+
+  const response = await request(app)
+    .patch("/v1/settings")
+    .set("Authorization", `Bearer ${makeToken("org-1")}`)
+    .send({
+      director_name: "Jane Director",
+      director_phone: "555-2222",
+      director_email: "jane@example.com",
+      default_message: "We are here for your family.",
+    });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.director_name, "Jane Director");
+  assert.equal(response.body.director_phone, "555-2222");
+  assert.equal(response.body.director_email, "jane@example.com");
+  assert.equal(response.body.default_message, "We are here for your family.");
 });
 


### PR DESCRIPTION
## Summary
- Adds Stripe subscription billing ($11.99/mo, 7-day trial): checkout, portal, webhooks, and `org_billing` table
- Syncs subscription status from Stripe on GET when webhooks lag; gates family link share/create on active subscription
- Adds funeral director fields and migration `003`
- Includes prior develop changes (SendGrid invite docs, etc.)

## Test plan
- [x] Run `npm run db:migrate` on production (migrations `002_org_billing`, `003_funeral_director`)
- [x] Set Stripe env vars on Railway (`STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`, checkout/portal URLs)
- [x] Configure Stripe webhook → `POST /v1/billing/webhook`
- [x] `npm run test` passes
- [x] Smoke test: checkout, subscription status, family link share (trialing/active vs expired)


Made with [Cursor](https://cursor.com)