### PR TITLE
Enforce org subscription and admin role on write routes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "openapi:lint": "spectral lint openapi.yaml",
     "openapi:validate": "swagger-cli validate openapi.yaml",
     "test:contract": "npm run openapi:lint && npm run openapi:validate",
-    "test:api": "node --import tsx --test test/*.test.ts test/auth/*.test.ts test/settings/*.test.ts test/staff/*.test.ts test/assignments/*.test.ts test/public/*.test.ts test/billing/*.test.ts",
+    "test:api": "node --import tsx --test test/*.test.ts test/auth/*.test.ts test/settings/*.test.ts test/staff/*.test.ts test/assignments/*.test.ts test/public/*.test.ts test/billing/*.test.ts test/writeAccess/*.test.ts",
     "test:db": "node --import tsx --test test/db/*.test.ts",
     "test": "npm run test:contract && npm run test:db && npm run test:api"
   },

--- a/src/auth/writeAccessMiddleware.ts
+++ b/src/auth/writeAccessMiddleware.ts
@@ -1,0 +1,64 @@
+import type { NextFunction, Response } from "express";
+import type { BillingService } from "../services/billingService";
+import { SubscriptionRequiredError } from "../services/billingService";
+import type { AuthenticatedRequest } from "./authMiddleware";
+
+function respondSubscriptionRequired(res: Response, error: SubscriptionRequiredError): void {
+  res.status(403).json({
+    code: error.code,
+    message: error.message,
+  });
+}
+
+function respondForbidden(res: Response, message: string): void {
+  res.status(403).json({
+    code: "forbidden",
+    message,
+  });
+}
+
+/** Org must have trialing or active subscription (all staff, including invited users). */
+export function requireActiveSubscription(billingService: BillingService) {
+  return async (req: AuthenticatedRequest, res: Response, next: NextFunction): Promise<void> => {
+    const orgId = req.auth?.orgId;
+    if (!orgId) {
+      res.status(401).json({
+        code: "unauthorized",
+        message: "Authentication is required.",
+      });
+      return;
+    }
+
+    try {
+      await billingService.assertOrgHasActiveSubscription(orgId);
+      next();
+    } catch (error) {
+      if (error instanceof SubscriptionRequiredError) {
+        respondSubscriptionRequired(res, error);
+        return;
+      }
+      next(error);
+    }
+  };
+}
+
+/** Admin-only write (role check). Use after requireAuth. */
+export function requireAdminWrite(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  if (!req.auth) {
+    res.status(401).json({
+      code: "unauthorized",
+      message: "Authentication is required.",
+    });
+    return;
+  }
+
+  if (req.auth.role !== "admin") {
+    respondForbidden(
+      res,
+      "You do not have permission to perform this action. Contact your funeral home admin.",
+    );
+    return;
+  }
+
+  next();
+}

--- a/src/controllers/assignmentController.ts
+++ b/src/controllers/assignmentController.ts
@@ -7,8 +7,6 @@ import {
   type AssignmentStatus,
   type AssignmentUpdateInput,
 } from "../services/assignmentService";
-import type { BillingService } from "../services/billingService";
-import { SubscriptionRequiredError } from "../services/billingService";
 import { FamilyLinkNotConfiguredError, isValidEmail, sendFamilyLinkByEmail } from "../services/inviteStaff";
 import { parseEtaTimeFromBody, serializeAssignmentEtaTime } from "../utils/etaTime";
 
@@ -100,18 +98,10 @@ export async function postAssignment(
   res.status(201).json(serializeAssignmentResponse(created));
 }
 
-function respondsSubscriptionRequired(res: Response, error: SubscriptionRequiredError): void {
-  res.status(403).json({
-    code: error.code,
-    message: error.message,
-  });
-}
-
 export async function patchAssignment(
   req: AuthenticatedRequest,
   res: Response,
   assignmentService: AssignmentService,
-  billingService: BillingService,
 ): Promise<void> {
   const orgId = req.auth?.orgId;
   const actorUserId = req.auth?.userId;
@@ -183,16 +173,7 @@ export async function patchAssignment(
     return;
   }
 
-  const issuingFamilyLink =
-    update.share_token !== undefined &&
-    update.share_token !== null &&
-    update.share_token.length > 0;
-
   try {
-    if (issuingFamilyLink) {
-      await billingService.assertOrgCanShareFamilyLinks(orgId);
-    }
-
     const updated = await assignmentService.updateByOrgIdAndId(orgId, id, update, actorUserId);
     if (!updated) {
       res.status(404).json({
@@ -217,10 +198,6 @@ export async function patchAssignment(
       });
       return;
     }
-    if (error instanceof SubscriptionRequiredError) {
-      respondsSubscriptionRequired(res, error);
-      return;
-    }
     throw error;
   }
 }
@@ -229,7 +206,6 @@ export async function postShareFamilyLinkByEmail(
   req: AuthenticatedRequest,
   res: Response,
   assignmentService: AssignmentService,
-  billingService: BillingService,
 ): Promise<void> {
   const orgId = req.auth?.orgId;
   if (!orgId) {
@@ -282,8 +258,6 @@ export async function postShareFamilyLinkByEmail(
   const familyLink = `${familyLinkBaseUrl}/family/${encodeURIComponent(assignment.share_token)}`;
 
   try {
-    await billingService.assertOrgCanShareFamilyLinks(orgId);
-
     await sendFamilyLinkByEmail({
       email,
       familyLink,
@@ -297,10 +271,6 @@ export async function postShareFamilyLinkByEmail(
     });
     res.status(202).json({ ok: true });
   } catch (error) {
-    if (error instanceof SubscriptionRequiredError) {
-      respondsSubscriptionRequired(res, error);
-      return;
-    }
     if (error instanceof FamilyLinkNotConfiguredError) {
       res.status(503).json({
         code: "family_link_not_configured",

--- a/src/routes/assignmentRoutes.ts
+++ b/src/routes/assignmentRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import { requireAuth, type AuthenticatedRequest } from "../auth/authMiddleware";
+import { requireActiveSubscription, requireAdminWrite } from "../auth/writeAccessMiddleware";
 import type { AppServices } from "../appServices";
 import {
   getAssignments,
@@ -11,30 +12,29 @@ import {
 
 export function createAssignmentRouter(services: AppServices): Router {
   const router = Router();
+  const requireWrite = [
+    requireAuth,
+    requireAdminWrite,
+    requireActiveSubscription(services.billingService),
+  ] as const;
 
   router.get("/", requireAuth, (req: Request, res: Response) =>
     getAssignments(req as AuthenticatedRequest, res, services.assignmentService),
   );
 
-  router.post("/", requireAuth, (req: Request, res: Response) =>
+  router.post("/", ...requireWrite, (req: Request, res: Response) =>
     postAssignment(req as AuthenticatedRequest, res, services.assignmentService),
   );
 
-  router.patch("/:id", requireAuth, (req: Request, res: Response) =>
-    patchAssignment(
-      req as AuthenticatedRequest,
-      res,
-      services.assignmentService,
-      services.billingService,
-    ),
+  router.patch("/:id", ...requireWrite, (req: Request, res: Response) =>
+    patchAssignment(req as AuthenticatedRequest, res, services.assignmentService),
   );
 
-  router.post("/:id/share/email", requireAuth, (req: Request, res: Response) =>
+  router.post("/:id/share/email", ...requireWrite, (req: Request, res: Response) =>
     postShareFamilyLinkByEmail(
       req as AuthenticatedRequest,
       res,
       services.assignmentService,
-      services.billingService,
     ),
   );
 

--- a/src/routes/settingsRoutes.ts
+++ b/src/routes/settingsRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import { requireAuth, type AuthenticatedRequest } from "../auth/authMiddleware";
+import { requireActiveSubscription, requireAdminWrite } from "../auth/writeAccessMiddleware";
 import type { AppServices } from "../appServices";
 import { getSettings, patchSettings } from "../controllers/settingsController";
 
@@ -10,8 +11,13 @@ export function createSettingsRouter(services: AppServices): Router {
   router.get("/", requireAuth, (req: Request, res: Response) =>
     getSettings(req as AuthenticatedRequest, res, services.settingsService),
   );
-  router.patch("/", requireAuth, (req: Request, res: Response) =>
-    patchSettings(req as AuthenticatedRequest, res, services.settingsService),
+  router.patch(
+    "/",
+    requireAuth,
+    requireAdminWrite,
+    requireActiveSubscription(services.billingService),
+    (req: Request, res: Response) =>
+      patchSettings(req as AuthenticatedRequest, res, services.settingsService),
   );
 
   return router;

--- a/src/routes/staffRoutes.ts
+++ b/src/routes/staffRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import type { Request, Response } from "express";
 import { requireAuth, type AuthenticatedRequest } from "../auth/authMiddleware";
 import { requireRole } from "../auth/requireRole";
+import { requireActiveSubscription, requireAdminWrite } from "../auth/writeAccessMiddleware";
 import type { AppServices } from "../appServices";
 import {
   deleteStaff,
@@ -17,11 +18,15 @@ import {
 
 export function createStaffRouter(services: AppServices): Router {
   const router = Router();
+  const requireAdminWriteAccess = [
+    requireAuth,
+    requireAdminWrite,
+    requireActiveSubscription(services.billingService),
+  ] as const;
 
   router.post(
     "/invite",
-    requireAuth,
-    requireRole("admin"),
+    ...requireAdminWriteAccess,
     (req: Request, res: Response) =>
       postStaffInvite(req as AuthenticatedRequest, res, services.inviteUserByEmail),
   );
@@ -30,38 +35,40 @@ export function createStaffRouter(services: AppServices): Router {
     getMyStaffProfile(req as AuthenticatedRequest, res, services.staffService),
   );
 
-  router.patch("/me", requireAuth, (req: Request, res: Response) =>
-    patchMyStaffProfile(req as AuthenticatedRequest, res, services.staffService),
+  router.patch(
+    "/me",
+    requireAuth,
+    requireActiveSubscription(services.billingService),
+    (req: Request, res: Response) =>
+      patchMyStaffProfile(req as AuthenticatedRequest, res, services.staffService),
   );
 
   router.get("/", requireAuth, requireRole("admin"), (req: Request, res: Response) =>
     getStaffList(req as AuthenticatedRequest, res, services.staffService),
   );
 
-  router.post("/", requireAuth, requireRole("admin"), (req: Request, res: Response) =>
+  router.post("/", ...requireAdminWriteAccess, (req: Request, res: Response) =>
     postStaff(req as AuthenticatedRequest, res, services.staffService),
   );
 
-  router.patch("/:id", requireAuth, requireRole("admin"), (req: Request, res: Response) =>
+  router.patch("/:id", ...requireAdminWriteAccess, (req: Request, res: Response) =>
     patchStaff(req as AuthenticatedRequest, res, services.staffService),
   );
 
-  router.delete("/:id", requireAuth, requireRole("admin"), (req: Request, res: Response) =>
+  router.delete("/:id", ...requireAdminWriteAccess, (req: Request, res: Response) =>
     deleteStaff(req as AuthenticatedRequest, res, services.staffService),
   );
 
   router.post(
     "/:id/activate",
-    requireAuth,
-    requireRole("admin"),
+    ...requireAdminWriteAccess,
     (req: Request, res: Response) =>
       postStaffActivate(req as AuthenticatedRequest, res, services.staffService),
   );
 
   router.post(
     "/:id/deactivate",
-    requireAuth,
-    requireRole("admin"),
+    ...requireAdminWriteAccess,
     (req: Request, res: Response) =>
       postStaffDeactivate(req as AuthenticatedRequest, res, services.staffService),
   );

--- a/src/routes/uploadRoutes.ts
+++ b/src/routes/uploadRoutes.ts
@@ -2,6 +2,7 @@ import multer from "multer";
 import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { requireAuth, type AuthenticatedRequest } from "../auth/authMiddleware";
+import { requireActiveSubscription, requireAdminWrite } from "../auth/writeAccessMiddleware";
 import type { AppServices } from "../appServices";
 import { postUploadImage } from "../controllers/uploadController";
 
@@ -41,6 +42,8 @@ export function createUploadRouter(services: AppServices): Router {
   router.post(
     "/image",
     requireAuth,
+    requireAdminWrite,
+    requireActiveSubscription(services.billingService),
     upload.single("file"),
     (req: Request, res: Response) =>
       postUploadImage(req as AuthenticatedRequest, res, services.storageUploadService),

--- a/src/services/billingService.ts
+++ b/src/services/billingService.ts
@@ -42,20 +42,26 @@ export class SubscriptionRequiredError extends Error {
   readonly code = "subscription_required";
 
   constructor(
-    message = "An active subscription is required to share family links. Subscribe in Settings → Payment.",
+    message = "An active subscription is required. Subscribe in Settings → Payment to continue.",
   ) {
     super(message);
   }
 }
 
-export function assertOrgCanShareFamilyLinks(view: SubscriptionView): void {
+export function assertOrgHasActiveSubscription(view: SubscriptionView): void {
   if (!view.is_subscribed) {
     throw new SubscriptionRequiredError();
   }
 }
 
+/** @deprecated Use assertOrgHasActiveSubscription */
+export function assertOrgCanShareFamilyLinks(view: SubscriptionView): void {
+  assertOrgHasActiveSubscription(view);
+}
+
 export type BillingService = {
   getSubscriptionView: (orgId: string) => Promise<SubscriptionView>;
+  assertOrgHasActiveSubscription: (orgId: string) => Promise<void>;
   assertOrgCanShareFamilyLinks: (orgId: string) => Promise<void>;
   createCheckoutSession: (input: {
     orgId: string;
@@ -306,9 +312,13 @@ export const defaultBillingService: BillingService = {
     return toSubscriptionView(record);
   },
 
-  async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
+  async assertOrgHasActiveSubscription(orgId: string): Promise<void> {
     const view = await this.getSubscriptionView(orgId);
-    assertOrgCanShareFamilyLinks(view);
+    assertOrgHasActiveSubscription(view);
+  },
+
+  async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
+    await this.assertOrgHasActiveSubscription(orgId);
   },
 
   async createCheckoutSession(input) {

--- a/test/assignments/assignments.test.ts
+++ b/test/assignments/assignments.test.ts
@@ -3,94 +3,25 @@ import test from "node:test";
 import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
+import { billingWithSubscribedOrgs } from "../helpers/inMemoryBillingService";
+import { createInMemoryAssignmentService } from "../helpers/inMemoryAssignmentService";
 import {
   type AssignmentCreateInput,
   type AssignmentService,
-  type AssignmentStatus,
   type AssignmentUpdateInput,
-  type PickupAssignmentRecord,
 } from "../../src/services/assignmentService";
 
 const JWT_SECRET = "test-secret-assignments";
 
-type AuditEntry = {
-  assignmentId: string;
-  orgId: string;
-  fromStatus: AssignmentStatus;
-  toStatus: AssignmentStatus;
-  actorUserId: string;
-};
-
-function makeToken(orgId: string, userId = "user-1"): string {
-  return jwt.sign({ sub: userId, role: "admin", org_id: orgId }, JWT_SECRET);
+function makeToken(orgId: string, userId = "user-1", role = "admin"): string {
+  return jwt.sign({ sub: userId, role, org_id: orgId }, JWT_SECRET);
 }
 
-function createInMemoryAssignmentService() {
-  const data = new Map<string, PickupAssignmentRecord[]>();
-  const audits: AuditEntry[] = [];
-  let counter = 1;
-
-  const listFor = (orgId: string) => data.get(orgId) ?? [];
-
-  const service: AssignmentService = {
-    async listByOrgId(orgId, sort) {
-      const items = [...listFor(orgId)];
-      if (sort === "-created_at") return items.reverse();
-      return items;
-    },
-
-    async createByOrgId(orgId, input) {
-      const item: PickupAssignmentRecord = {
-        id: `assignment-${counter++}`,
-        org_id: orgId,
-        decedent_name: input.decedent_name,
-        pickup_address: input.pickup_address,
-        contact_name: input.contact_name,
-        contact_phone: input.contact_phone,
-        notes: input.notes ?? null,
-        assigned_staff_id: input.assigned_staff_id ?? null,
-        status: (input.status ?? "pending") as AssignmentStatus,
-      };
-      data.set(orgId, [...listFor(orgId), item]);
-      return item;
-    },
-
-    async updateByOrgIdAndId(orgId, id, input, actorUserId) {
-      const items = listFor(orgId);
-      const idx = items.findIndex((i) => i.id === id);
-      if (idx < 0) return null;
-
-      const current = items[idx];
-      const nextStatus = (input.status ?? current.status) as AssignmentStatus;
-
-      const next: PickupAssignmentRecord = {
-        ...current,
-        ...input,
-        status: nextStatus,
-      };
-      const arr = [...items];
-      arr[idx] = next;
-      data.set(orgId, arr);
-
-      if (current.status !== next.status) {
-        audits.push({
-          assignmentId: id,
-          orgId,
-          fromStatus: current.status,
-          toStatus: next.status,
-          actorUserId,
-        });
-      }
-
-      return next;
-    },
-
-    async getFamilyShareEmailContextByOrgIdAndId() {
-      return null;
-    },
-  };
-
-  return { service, audits };
+function appWithAssignments(service: AssignmentService, ...orgIds: string[]) {
+  return createApp({
+    assignmentService: service,
+    billingService: billingWithSubscribedOrgs(...orgIds),
+  });
 }
 
 test.before(() => {
@@ -106,7 +37,7 @@ test("GET /v1/assignments returns 401 without token", async () => {
 
 test("POST /v1/assignments creates assignment", async () => {
   const { service } = createInMemoryAssignmentService();
-  const app = createApp({ assignmentService: service });
+  const app = appWithAssignments(service, "org-1");
   const response = await request(app)
     .post("/v1/assignments")
     .set("Authorization", `Bearer ${makeToken("org-1")}`)
@@ -124,7 +55,7 @@ test("POST /v1/assignments creates assignment", async () => {
 
 test("GET /v1/assignments is org-scoped", async () => {
   const { service } = createInMemoryAssignmentService();
-  const app = createApp({ assignmentService: service });
+  const app = appWithAssignments(service, "org-1", "org-2");
 
   await request(app)
     .post("/v1/assignments")
@@ -158,7 +89,7 @@ test("GET /v1/assignments is org-scoped", async () => {
 
 test("PATCH /v1/assignments/:id updates status and creates audit log", async () => {
   const { service, audits } = createInMemoryAssignmentService();
-  const app = createApp({ assignmentService: service });
+  const app = appWithAssignments(service, "org-1");
 
   const created = await request(app)
     .post("/v1/assignments")
@@ -185,7 +116,7 @@ test("PATCH /v1/assignments/:id updates status and creates audit log", async () 
 
 test("PATCH /v1/assignments/:id 404 for cross-org assignment", async () => {
   const { service } = createInMemoryAssignmentService();
-  const app = createApp({ assignmentService: service });
+  const app = appWithAssignments(service, "org-1", "org-2");
 
   const created = await request(app)
     .post("/v1/assignments")

--- a/test/auth/staffInvite.test.ts
+++ b/test/auth/staffInvite.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
+import { billingWithSubscribedOrgs } from "../helpers/inMemoryBillingService";
 
 const JWT_SECRET = "test-secret-invite";
 
@@ -36,7 +37,7 @@ test("POST /v1/staff/invite returns 403 for non-admin", async () => {
 
 test("POST /v1/staff/invite returns 400 for invalid email", async () => {
   process.env.JWT_SECRET = JWT_SECRET;
-  const app = createApp();
+  const app = createApp({ billingService: billingWithSubscribedOrgs("org-1") });
   const response = await request(app)
     .post("/v1/staff/invite")
     .set("Authorization", `Bearer ${adminToken()}`)
@@ -49,6 +50,7 @@ test("POST /v1/staff/invite returns 400 for invalid email", async () => {
 test("POST /v1/staff/invite returns 202 when invite succeeds", async () => {
   process.env.JWT_SECRET = JWT_SECRET;
   const app = createApp({
+    billingService: billingWithSubscribedOrgs("org-1"),
     inviteUserByEmail: async (input: { email: string }) => {
       assert.equal(input.email, "staff@example.com");
     },
@@ -70,6 +72,7 @@ test("POST /v1/staff/invite returns 202 when invite succeeds", async () => {
 test("POST /v1/staff/invite returns 502 when provider fails", async () => {
   process.env.JWT_SECRET = JWT_SECRET;
   const app = createApp({
+    billingService: billingWithSubscribedOrgs("org-1"),
     inviteUserByEmail: async (_input: { email: string }) => {
       throw new Error("duplicate user");
     },
@@ -90,7 +93,7 @@ test("POST /v1/staff/invite returns 503 when invite service is not configured", 
   delete process.env.INVITE_FROM_EMAIL;
   delete process.env.INVITE_SIGNUP_URL;
 
-  const app = createApp();
+  const app = createApp({ billingService: billingWithSubscribedOrgs("org-1") });
   const response = await request(app)
     .post("/v1/staff/invite")
     .set("Authorization", `Bearer ${adminToken()}`)

--- a/test/billing/billing.test.ts
+++ b/test/billing/billing.test.ts
@@ -3,72 +3,13 @@ import test from "node:test";
 import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
-import {
-  assertOrgCanShareFamilyLinks,
-  BILLING_PLAN_AMOUNT_CENTS,
-  BILLING_TRIAL_DAYS,
-  type BillingService,
-  type SubscriptionView,
-} from "../../src/services/billingService";
+import { BILLING_PLAN_AMOUNT_CENTS, BILLING_TRIAL_DAYS } from "../../src/services/billingService";
+import { createInMemoryBillingService } from "../helpers/inMemoryBillingService";
 
 const JWT_SECRET = "test-secret-billing";
 
 function makeToken(orgId: string, role = "admin"): string {
   return jwt.sign({ sub: "user-1", role, org_id: orgId }, JWT_SECRET);
-}
-
-function createInMemoryBillingService(): BillingService {
-  const store = new Map<string, SubscriptionView>();
-
-  const defaultView = (orgId: string): SubscriptionView => ({
-    org_id: orgId,
-    status: "none",
-    plan_amount_cents: BILLING_PLAN_AMOUNT_CENTS,
-    plan_interval: "month",
-    trial_days: BILLING_TRIAL_DAYS,
-    trial_ends_at: null,
-    current_period_end: null,
-    cancel_at_period_end: false,
-    is_subscribed: false,
-  });
-
-  return {
-    async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
-      return store.get(orgId) ?? defaultView(orgId);
-    },
-
-    async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
-      const view = await this.getSubscriptionView(orgId);
-      assertOrgCanShareFamilyLinks(view);
-    },
-
-    async createCheckoutSession(input) {
-      const current = await this.getSubscriptionView(input.orgId);
-      if (current.is_subscribed) {
-        const error = new Error("already subscribed");
-        (error as Error & { code?: string }).code = "subscription_exists";
-        throw error;
-      }
-      return {
-        checkout_url: "https://checkout.stripe.test/session",
-        session_id: "cs_test_123",
-      };
-    },
-
-    async createPortalSession(input) {
-      const current = await this.getSubscriptionView(input.orgId);
-      if (current.status === "none") {
-        const error = new Error("missing customer");
-        (error as Error & { code?: string }).code = "billing_customer_missing";
-        throw error;
-      }
-      return { portal_url: "https://billing.stripe.test/portal" };
-    },
-
-    async handleWebhookEvent() {
-      // no-op for API tests
-    },
-  };
 }
 
 test.before(() => {

--- a/test/db/migrations.test.ts
+++ b/test/db/migrations.test.ts
@@ -29,6 +29,7 @@ test("migrations create core tables", async () => {
     assert.deepEqual(tableNames, [
       "assignment_audit_logs",
       "funeral_homes",
+      "org_billing",
       "pickup_assignments",
       "staff_audit_logs",
       "staff_invites",

--- a/test/helpers/inMemoryAssignmentService.ts
+++ b/test/helpers/inMemoryAssignmentService.ts
@@ -1,0 +1,81 @@
+import {
+  type AssignmentService,
+  type AssignmentStatus,
+  type PickupAssignmentRecord,
+} from "../../src/services/assignmentService";
+
+export type AssignmentAuditEntry = {
+  assignmentId: string;
+  orgId: string;
+  fromStatus: AssignmentStatus;
+  toStatus: AssignmentStatus;
+  actorUserId: string;
+};
+
+export function createInMemoryAssignmentService() {
+  const data = new Map<string, PickupAssignmentRecord[]>();
+  const audits: AssignmentAuditEntry[] = [];
+  let counter = 1;
+
+  const listFor = (orgId: string) => data.get(orgId) ?? [];
+
+  const service: AssignmentService = {
+    async listByOrgId(orgId, sort) {
+      const items = [...listFor(orgId)];
+      if (sort === "-created_at") return items.reverse();
+      return items;
+    },
+
+    async createByOrgId(orgId, input) {
+      const item: PickupAssignmentRecord = {
+        id: `assignment-${counter++}`,
+        org_id: orgId,
+        decedent_name: input.decedent_name,
+        pickup_address: input.pickup_address,
+        contact_name: input.contact_name,
+        contact_phone: input.contact_phone,
+        notes: input.notes ?? null,
+        assigned_staff_id: input.assigned_staff_id ?? null,
+        status: (input.status ?? "pending") as AssignmentStatus,
+      };
+      data.set(orgId, [...listFor(orgId), item]);
+      return item;
+    },
+
+    async updateByOrgIdAndId(orgId, id, input, actorUserId) {
+      const items = listFor(orgId);
+      const idx = items.findIndex((i) => i.id === id);
+      if (idx < 0) return null;
+
+      const current = items[idx];
+      const nextStatus = (input.status ?? current.status) as AssignmentStatus;
+
+      const next: PickupAssignmentRecord = {
+        ...current,
+        ...input,
+        status: nextStatus,
+      };
+      const arr = [...items];
+      arr[idx] = next;
+      data.set(orgId, arr);
+
+      if (current.status !== next.status) {
+        audits.push({
+          assignmentId: id,
+          orgId,
+          fromStatus: current.status,
+          toStatus: next.status,
+          actorUserId,
+        });
+      }
+
+      return next;
+    },
+
+    async getFamilyShareEmailContextByOrgIdAndId() {
+      return null;
+    },
+  };
+
+  return { service, audits };
+}

--- a/test/helpers/inMemoryBillingService.ts
+++ b/test/helpers/inMemoryBillingService.ts
@@ -1,0 +1,103 @@
+import {
+  assertOrgCanShareFamilyLinks,
+  assertOrgHasActiveSubscription,
+  BILLING_PLAN_AMOUNT_CENTS,
+  BILLING_TRIAL_DAYS,
+  type BillingService,
+  type SubscriptionView,
+} from "../../src/services/billingService";
+
+export function createInMemoryBillingService(
+  initial?: Partial<Record<string, Partial<SubscriptionView>>>,
+): BillingService & {
+  setSubscribed(orgId: string, subscribed: boolean): void;
+} {
+  const store = new Map<string, SubscriptionView>();
+
+  const defaultView = (orgId: string): SubscriptionView => {
+    const override = initial?.[orgId];
+    const base: SubscriptionView = {
+      org_id: orgId,
+      status: "none",
+      plan_amount_cents: BILLING_PLAN_AMOUNT_CENTS,
+      plan_interval: "month",
+      trial_days: BILLING_TRIAL_DAYS,
+      trial_ends_at: null,
+      current_period_end: null,
+      cancel_at_period_end: false,
+      is_subscribed: false,
+    };
+    if (!override) return base;
+    return { ...base, ...override, org_id: orgId };
+  };
+
+  const service = {
+    async getSubscriptionView(orgId: string): Promise<SubscriptionView> {
+      return store.get(orgId) ?? defaultView(orgId);
+    },
+
+    async assertOrgHasActiveSubscription(orgId: string): Promise<void> {
+      const view = await this.getSubscriptionView(orgId);
+      assertOrgHasActiveSubscription(view);
+    },
+
+    async assertOrgCanShareFamilyLinks(orgId: string): Promise<void> {
+      await this.assertOrgHasActiveSubscription(orgId);
+    },
+
+    async createCheckoutSession(input: { orgId: string }) {
+      const current = await this.getSubscriptionView(input.orgId);
+      if (current.is_subscribed) {
+        const error = new Error("already subscribed");
+        (error as Error & { code?: string }).code = "subscription_exists";
+        throw error;
+      }
+      return {
+        checkout_url: "https://checkout.stripe.test/session",
+        session_id: "cs_test_123",
+      };
+    },
+
+    async createPortalSession(input: { orgId: string }) {
+      const current = await this.getSubscriptionView(input.orgId);
+      if (current.status === "none") {
+        const error = new Error("missing customer");
+        (error as Error & { code?: string }).code = "billing_customer_missing";
+        throw error;
+      }
+      return { portal_url: "https://billing.stripe.test/portal" };
+    },
+
+    async handleWebhookEvent() {
+      // no-op for API tests
+    },
+
+    setSubscribed(orgId: string, subscribed: boolean): void {
+      const current = store.get(orgId) ?? defaultView(orgId);
+      store.set(orgId, {
+        ...current,
+        status: subscribed ? "active" : "none",
+        is_subscribed: subscribed,
+      });
+    },
+  };
+
+  for (const [orgId, view] of Object.entries(initial ?? {})) {
+    if (view?.is_subscribed) {
+      service.setSubscribed(orgId, true);
+    }
+  }
+
+  return service;
+}
+
+/** Marks the given orgs as subscribed for write-route API tests. */
+export function billingWithSubscribedOrgs(
+  ...orgIds: string[]
+): ReturnType<typeof createInMemoryBillingService> {
+  const billing = createInMemoryBillingService();
+  for (const orgId of orgIds) {
+    billing.setSubscribed(orgId, true);
+  }
+  return billing;
+}

--- a/test/helpers/inMemorySettingsService.ts
+++ b/test/helpers/inMemorySettingsService.ts
@@ -1,0 +1,35 @@
+import type { SettingsRecord, SettingsService, SettingsUpdateInput } from "../../src/services/settingsService";
+
+export function createInMemorySettingsService(): SettingsService {
+  const store = new Map<string, SettingsRecord>();
+
+  return {
+    async getByOrgId(orgId: string): Promise<SettingsRecord> {
+      return (
+        store.get(orgId) ?? {
+          org_id: orgId,
+          director_name: "",
+          director_phone: "",
+          director_email: null,
+          director_image_url: null,
+          funeral_home_name: "",
+          funeral_home_phone: "",
+          funeral_home_address: "",
+          logo_url: null,
+          default_message: null,
+        }
+      );
+    },
+
+    async upsertByOrgId(orgId: string, input: SettingsUpdateInput): Promise<SettingsRecord> {
+      const current = await this.getByOrgId(orgId);
+      const next: SettingsRecord = {
+        ...current,
+        ...input,
+        org_id: orgId,
+      };
+      store.set(orgId, next);
+      return next;
+    },
+  };
+}

--- a/test/settings/settings.test.ts
+++ b/test/settings/settings.test.ts
@@ -3,46 +3,14 @@ import test from "node:test";
 import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
-import type { SettingsRecord, SettingsService, SettingsUpdateInput } from "../../src/services/settingsService";
+import { billingWithSubscribedOrgs } from "../helpers/inMemoryBillingService";
+import { createInMemorySettingsService } from "../helpers/inMemorySettingsService";
+import type { SettingsUpdateInput } from "../../src/services/settingsService";
 
 const JWT_SECRET = "test-secret-settings";
 
 function makeToken(orgId: string, role = "admin"): string {
   return jwt.sign({ sub: "user-1", role, org_id: orgId }, JWT_SECRET);
-}
-
-function createInMemorySettingsService(): SettingsService {
-  const store = new Map<string, SettingsRecord>();
-
-  return {
-    async getByOrgId(orgId: string): Promise<SettingsRecord> {
-      return (
-        store.get(orgId) ?? {
-          org_id: orgId,
-          director_name: "",
-          director_phone: "",
-          director_email: null,
-          director_image_url: null,
-          funeral_home_name: "",
-          funeral_home_phone: "",
-          funeral_home_address: "",
-          logo_url: null,
-          default_message: null,
-        }
-      );
-    },
-
-    async upsertByOrgId(orgId: string, input: SettingsUpdateInput): Promise<SettingsRecord> {
-      const current = await this.getByOrgId(orgId);
-      const next: SettingsRecord = {
-        ...current,
-        ...input,
-        org_id: orgId,
-      };
-      store.set(orgId, next);
-      return next;
-    },
-  };
 }
 
 test.before(() => {
@@ -67,7 +35,10 @@ test("GET /v1/settings returns org-scoped default settings", async () => {
 
 test("PATCH /v1/settings updates only authenticated org data", async () => {
   const settingsService = createInMemorySettingsService();
-  const app = createApp({ settingsService });
+  const app = createApp({
+    settingsService,
+    billingService: billingWithSubscribedOrgs("org-1", "org-2"),
+  });
 
   const patchResponse = await request(app)
     .patch("/v1/settings")
@@ -90,7 +61,10 @@ test("PATCH /v1/settings updates only authenticated org data", async () => {
 });
 
 test("PATCH /v1/settings returns 400 for invalid payload", async () => {
-  const app = createApp({ settingsService: createInMemorySettingsService() });
+  const app = createApp({
+    settingsService: createInMemorySettingsService(),
+    billingService: billingWithSubscribedOrgs("org-1"),
+  });
   const response = await request(app)
     .patch("/v1/settings")
     .set("Authorization", `Bearer ${makeToken("org-1")}`)
@@ -102,7 +76,10 @@ test("PATCH /v1/settings returns 400 for invalid payload", async () => {
 
 test("PATCH /v1/settings updates funeral director fields", async () => {
   const settingsService = createInMemorySettingsService();
-  const app = createApp({ settingsService });
+  const app = createApp({
+    settingsService,
+    billingService: billingWithSubscribedOrgs("org-1"),
+  });
 
   const response = await request(app)
     .patch("/v1/settings")

--- a/test/staff/staff.test.ts
+++ b/test/staff/staff.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import jwt from "jsonwebtoken";
 import request from "supertest";
 import { createApp } from "../../src/app";
+import { billingWithSubscribedOrgs } from "../helpers/inMemoryBillingService";
 import type { StaffCreateInput, StaffMemberRecord, StaffService, StaffUpdateInput } from "../../src/services/staffService";
 
 const JWT_SECRET = "test-secret-staff";
@@ -13,6 +14,13 @@ function makeToken(orgId: string): string {
 
 function makeUserToken(orgId: string): string {
   return jwt.sign({ sub: "user-1", role: "user", org_id: orgId }, JWT_SECRET);
+}
+
+function appWithStaff(service: StaffService, ...orgIds: string[]) {
+  return createApp({
+    staffService: service,
+    billingService: billingWithSubscribedOrgs(...orgIds),
+  });
 }
 
 function createInMemoryStaffService(): StaffService {
@@ -79,7 +87,7 @@ test("GET /v1/staff returns 401 without token", async () => {
 });
 
 test("POST /v1/staff creates staff for authenticated org", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1");
   const response = await request(app)
     .post("/v1/staff")
     .set("Authorization", `Bearer ${makeToken("org-1")}`)
@@ -92,7 +100,7 @@ test("POST /v1/staff creates staff for authenticated org", async () => {
 
 test("GET /v1/staff is org-scoped", async () => {
   const service = createInMemoryStaffService();
-  const app = createApp({ staffService: service });
+  const app = appWithStaff(service, "org-1", "org-2");
 
   await request(app)
     .post("/v1/staff")
@@ -116,7 +124,7 @@ test("GET /v1/staff is org-scoped", async () => {
 });
 
 test("PATCH /v1/staff/:id updates member", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1");
 
   const createRes = await request(app)
     .post("/v1/staff")
@@ -133,7 +141,7 @@ test("PATCH /v1/staff/:id updates member", async () => {
 });
 
 test("DELETE /v1/staff/:id removes member", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1");
 
   const createRes = await request(app)
     .post("/v1/staff")
@@ -148,7 +156,7 @@ test("DELETE /v1/staff/:id removes member", async () => {
 });
 
 test("PATCH /v1/staff/:id returns 404 for cross-org access", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1", "org-2");
 
   const createRes = await request(app)
     .post("/v1/staff")
@@ -170,7 +178,7 @@ test("GET /v1/staff returns 403 for non-admin", async () => {
 });
 
 test("POST /v1/staff/:id/deactivate toggles active to false", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1");
 
   const createRes = await request(app)
     .post("/v1/staff")
@@ -186,7 +194,7 @@ test("POST /v1/staff/:id/deactivate toggles active to false", async () => {
 });
 
 test("POST /v1/staff/:id/activate toggles active to true", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
+  const app = appWithStaff(createInMemoryStaffService(), "org-1");
 
   const createRes = await request(app)
     .post("/v1/staff")

--- a/test/writeAccess/writeAccess.test.ts
+++ b/test/writeAccess/writeAccess.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { createApp } from "../../src/app";
+import { createInMemoryAssignmentService } from "../helpers/inMemoryAssignmentService";
+import { createInMemorySettingsService } from "../helpers/inMemorySettingsService";
+import { billingWithSubscribedOrgs, createInMemoryBillingService } from "../helpers/inMemoryBillingService";
+
+const JWT_SECRET = "test-secret-write-access";
+
+function makeToken(orgId: string, role: "admin" | "user" = "admin"): string {
+  return jwt.sign({ sub: "user-1", role, org_id: orgId }, JWT_SECRET);
+}
+
+test.before(() => {
+  process.env.JWT_SECRET = JWT_SECRET;
+  process.env.STRIPE_CHECKOUT_SUCCESS_URL = "everroute://billing/success";
+  process.env.STRIPE_CHECKOUT_CANCEL_URL = "everroute://billing/cancel";
+  process.env.STRIPE_PORTAL_RETURN_URL = "everroute://billing/portal";
+});
+
+test("non-admin cannot POST /v1/assignments when subscribed", async () => {
+  const { service } = createInMemoryAssignmentService();
+  const app = createApp({
+    assignmentService: service,
+    billingService: billingWithSubscribedOrgs("org-1"),
+  });
+
+  const response = await request(app)
+    .post("/v1/assignments")
+    .set("Authorization", `Bearer ${makeToken("org-1", "user")}`)
+    .send({
+      decedent_name: "Blocked",
+      pickup_address: "A",
+      contact_name: "C",
+      contact_phone: "1",
+    });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body.code, "forbidden");
+});
+
+test("admin cannot POST /v1/assignments without active subscription", async () => {
+  const { service } = createInMemoryAssignmentService();
+  const billing = createInMemoryBillingService();
+  const app = createApp({ assignmentService: service, billingService: billing });
+
+  const response = await request(app)
+    .post("/v1/assignments")
+    .set("Authorization", `Bearer ${makeToken("org-unsub")}`)
+    .send({
+      decedent_name: "Blocked",
+      pickup_address: "A",
+      contact_name: "C",
+      contact_phone: "1",
+    });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body.code, "subscription_required");
+});
+
+test("admin can POST /v1/billing/checkout-session without subscription", async () => {
+  const billing = createInMemoryBillingService();
+  const app = createApp({ billingService: billing });
+
+  const response = await request(app)
+    .post("/v1/billing/checkout-session")
+    .set("Authorization", `Bearer ${makeToken("org-unsub")}`);
+
+  assert.equal(response.status, 200);
+  assert.ok(response.body.checkout_url);
+});
+
+test("user cannot PATCH /v1/staff/me without subscription", async () => {
+  const billing = createInMemoryBillingService();
+  const app = createApp({ billingService: billing });
+
+  const response = await request(app)
+    .patch("/v1/staff/me")
+    .set("Authorization", `Bearer ${makeToken("org-1", "user")}`)
+    .send({ name: "Updated Name" });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body.code, "subscription_required");
+});
+
+test("non-admin cannot PATCH /v1/settings when subscribed", async () => {
+  const app = createApp({
+    settingsService: createInMemorySettingsService(),
+    billingService: billingWithSubscribedOrgs("org-1"),
+  });
+
+  const response = await request(app)
+    .patch("/v1/settings")
+    .set("Authorization", `Bearer ${makeToken("org-1", "user")}`)
+    .send({ funeral_home_name: "Blocked" });
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body.code, "forbidden");
+});


### PR DESCRIPTION
Add write-access middleware so non-admins and expired orgs cannot mutate data; billing checkout/portal stay available to admins without a subscription.