### PR TITLE
Allow user role to read staff list

### DIFF
--- a/src/routes/staffRoutes.ts
+++ b/src/routes/staffRoutes.ts
@@ -43,7 +43,7 @@ export function createStaffRouter(services: AppServices): Router {
       patchMyStaffProfile(req as AuthenticatedRequest, res, services.staffService),
   );
 
-  router.get("/", requireAuth, requireRole("admin"), (req: Request, res: Response) =>
+  router.get("/", requireAuth, (req: Request, res: Response) =>
     getStaffList(req as AuthenticatedRequest, res, services.staffService),
   );
 

--- a/test/staff/staff.test.ts
+++ b/test/staff/staff.test.ts
@@ -171,10 +171,22 @@ test("PATCH /v1/staff/:id returns 404 for cross-org access", async () => {
   assert.equal(updateRes.status, 404);
 });
 
-test("GET /v1/staff returns 403 for non-admin", async () => {
-  const app = createApp({ staffService: createInMemoryStaffService() });
-  const response = await request(app).get("/v1/staff").set("Authorization", `Bearer ${makeUserToken("org-1")}`);
-  assert.equal(response.status, 403);
+test("GET /v1/staff returns org staff for non-admin (read access)", async () => {
+  const service = createInMemoryStaffService();
+  const app = appWithStaff(service, "org-1");
+
+  await request(app)
+    .post("/v1/staff")
+    .set("Authorization", `Bearer ${makeToken("org-1")}`)
+    .send({ name: "Alice", phone: "555-1000" } satisfies StaffCreateInput);
+
+  const response = await request(app)
+    .get("/v1/staff")
+    .set("Authorization", `Bearer ${makeUserToken("org-1")}`);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.items.length, 1);
+  assert.equal(response.body.items[0].name, "Alice");
 });
 
 test("POST /v1/staff/:id/deactivate toggles active to false", async () => {


### PR DESCRIPTION
## Summary
- Open `GET /v1/staff` to all authenticated org members so invited users can load Home and Staff without 403.
- Staff create/update/invite/deactivate remain admin-only with subscription checks.

## Test plan
- [x] Sign in as invited `user` — Home dashboard loads with staff count
- [x] Staff tab shows org staff list (no invite/add buttons)
- [x] Sign in as `admin` — staff list and admin actions still work
- [x] `npm run test:api` passes on develop


Made with [Cursor](https://cursor.com)